### PR TITLE
[Feat] Player Spawn/ Camera Follow

### DIFF
--- a/Assets/HSD.meta
+++ b/Assets/HSD.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba8c50d994072e34f8dc3765020a4d55
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HSD/Scripts.meta
+++ b/Assets/HSD/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c07a0a0d1da1673468579fdff2964dc6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HSD/Scripts/CustomProperty.cs.meta
+++ b/Assets/HSD/Scripts/CustomProperty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23b3ceef69fc80244b5a961a390bb720
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Projectile.prefab
+++ b/Assets/Resources/Prefabs/Projectile.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 4078480300867195377}
   - component: {fileID: 7804357314454640223}
   - component: {fileID: 2398114623178038475}
-  - component: {fileID: 6685754623727689472}
-  - component: {fileID: 7695727515318565471}
-  - component: {fileID: 8095797937838405326}
+  - component: {fileID: 6515520639368925497}
+  - component: {fileID: -1744257906108635217}
+  - component: {fileID: 5077522412435928998}
   m_Layer: 0
   m_Name: Projectile
-  m_TagString: Untagged
+  m_TagString: Bullet
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -78,7 +78,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 65e29bc6898ce1f4d9afb66da8fa367f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -106,6 +106,8 @@ MonoBehaviour:
   explosionMask: {fileID: 0}
   explosionScale: 1
   damage: 100
+  explosionEffect: {fileID: 739683856073798810, guid: 7841814d350503a4e8bd5f49a48ea62b, type: 3}
+  delay: 2
 --- !u!50 &2398114623178038475
 Rigidbody2D:
   serializedVersion: 4
@@ -133,8 +135,8 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!58 &6685754623727689472
-CircleCollider2D:
+--- !u!60 &6515520639368925497
+PolygonCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -166,9 +168,30 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
---- !u!114 &7695727515318565471
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.39999998, y: 0.26999998}
+      - {x: 0.25, y: 0.29999998}
+      - {x: -0.44, y: 0.29999998}
+      - {x: -0.5, y: 0.21}
+      - {x: -0.5, y: -0.26999998}
+      - {x: -0.42, y: -0.32999998}
+      - {x: 0.03, y: -0.32999998}
+      - {x: 0.21, y: -0.32}
+      - {x: 0.37, y: -0.25}
+      - {x: 0.5, y: -0.11}
+      - {x: 0.5, y: 0.12}
+  m_UseDelaunayMesh: 0
+--- !u!114 &-1744257906108635217
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -187,11 +210,11 @@ MonoBehaviour:
   OwnershipTransfer: 0
   observableSearch: 2
   ObservedComponents:
-  - {fileID: 8095797937838405326}
+  - {fileID: 5077522412435928998}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &8095797937838405326
+--- !u!114 &5077522412435928998
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Resources/Prefabs/Projectile.prefab.meta
+++ b/Assets/Resources/Prefabs/Projectile.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6660d23fa609c7b429726b1dbac0125b
+guid: 026f3f2646307f045819c010ae1090f2
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Workspace/CSJ/CSJ_Scripts/TurnController.cs
+++ b/Assets/Workspace/CSJ/CSJ_Scripts/TurnController.cs
@@ -21,8 +21,8 @@ public class TurnController : MonoBehaviourPunCallbacks
         tanks = FindObjectsOfType<PlayerController>();
 
         int playerCount = PhotonNetwork.CountOfPlayers;
-        // 추후 연계하여 조절
-        if (CustomProperty.GetTurnRandom())
+        // 추후 연계하여 조절 TODO : 임시 크래쉬 수정
+        if (true)//CustomProperty.GetTurnRandom())
         {
             List<int> randNumList = new();
             for (int i = 0; i < playerCount; i++)

--- a/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
@@ -7,21 +7,46 @@ using UnityEngine.UI;
 
 public class TestBattleManager : MonoBehaviourPun
 {
+    [SerializeField] private List<Transform> _spawnPoint;
     [SerializeField] Button _turnEndButton;
     private PlayerController _playerController;
+    private TestNetworkManager _networkManager;
 
     private void Start()
     {
         _turnEndButton.onClick.AddListener(TestTurnEnd);
+        PlayerSpawn();
     }
     private void TestTurnEnd()
     {
         if (_playerController != null)
             _playerController.ResetTurn();
-       // photonView.RPC("RPC_TurnFinished", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
+        photonView.RPC("RPC_TurnFinished", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
     }
     public void RegisterPlayer(PlayerController playerController)
     {
         _playerController = playerController;
+    }
+    private void PlayerSpawn()
+    {
+        if (!PhotonNetwork.IsMasterClient) return;
+
+        Photon.Realtime.Player[] players = PhotonNetwork.PlayerList;
+
+        for (int i = 0; i < players.Length; i++)
+        {
+            if (i >= _spawnPoint.Count) break;
+
+            Vector3 spawnPos = _spawnPoint[i].position;
+
+            // 소유자를 명시하기 위해 커스텀 RPC로 생성 요청
+            photonView.RPC("RPC_SpawnTank", players[i], spawnPos);
+        }
+    }
+
+    [PunRPC]
+    private void RPC_SpawnTank(Vector3 spawnPos)
+    {
+        PhotonNetwork.Instantiate("Prefabs/Test Tank", spawnPos, Quaternion.identity);
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
@@ -29,17 +29,17 @@ public class TestBattleManager : MonoBehaviourPun
     }
     private void PlayerSpawn()
     {
-        if (!PhotonNetwork.IsMasterClient) return;
+        if (!PhotonNetwork.IsMasterClient)
+            return;
 
         Photon.Realtime.Player[] players = PhotonNetwork.PlayerList;
 
         for (int i = 0; i < players.Length; i++)
         {
-            if (i >= _spawnPoint.Count) break;
+            if (i >= _spawnPoint.Count)
+                break;
 
             Vector3 spawnPos = _spawnPoint[i].position;
-
-            // 소유자를 명시하기 위해 커스텀 RPC로 생성 요청
             photonView.RPC("RPC_SpawnTank", players[i], spawnPos);
         }
     }

--- a/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
@@ -9,6 +9,7 @@ public class TestBattleManager : MonoBehaviourPun
 {
     [SerializeField] private List<Transform> _spawnPoint;
     [SerializeField] Button _turnEndButton;
+    [SerializeField] private MSKTurnController _turnController;
     private PlayerController _playerController;
     private TestNetworkManager _networkManager;
 
@@ -16,13 +17,19 @@ public class TestBattleManager : MonoBehaviourPun
     {
         _turnEndButton.onClick.AddListener(TestTurnEnd);
         PlayerSpawn();
+        _turnController.photonView.RPC("RPC_Spawned", RpcTarget.All);
+
+        _playerController.OnPlayerAttacked += PlayerAttacked;
     }
+
     private void TestTurnEnd()
     {
         if (_playerController != null)
             _playerController.ResetTurn();
-        photonView.RPC("RPC_TurnFinished", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
+        _turnController.photonView.RPC("RPC_TurnFinished", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
     }
+
+
     public void RegisterPlayer(PlayerController playerController)
     {
         _playerController = playerController;
@@ -48,5 +55,10 @@ public class TestBattleManager : MonoBehaviourPun
     private void RPC_SpawnTank(Vector3 spawnPos)
     {
         PhotonNetwork.Instantiate("Prefabs/Test Tank", spawnPos, Quaternion.identity);
+    }
+
+    private void PlayerAttacked()
+    {
+        _turnController.photonView.RPC("RPC_TurnFinished", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
@@ -25,7 +25,7 @@ public class TestBattleManager : MonoBehaviourPun
     private void TestTurnEnd()
     {
         if (_playerController != null)
-            _playerController.ResetTurn();
+            _playerController.EndPlayerTurn();
         _turnController.photonView.RPC("RPC_TurnFinished", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
     }
 

--- a/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/BattleManager.cs
@@ -1,7 +1,5 @@
 using Photon.Pun;
-using System.Collections;
 using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -18,8 +16,11 @@ public class TestBattleManager : MonoBehaviourPun
         _turnEndButton.onClick.AddListener(TestTurnEnd);
         PlayerSpawn();
         _turnController.photonView.RPC("RPC_Spawned", RpcTarget.All);
+    }
 
-        _playerController.OnPlayerAttacked += PlayerAttacked;
+    private void PlayerAttacked()
+    {
+        _turnController.photonView.RPC("RPC_TurnFinished", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
     }
 
     private void TestTurnEnd()
@@ -33,7 +34,9 @@ public class TestBattleManager : MonoBehaviourPun
     public void RegisterPlayer(PlayerController playerController)
     {
         _playerController = playerController;
+        _playerController.OnPlayerAttacked += PlayerAttacked;
     }
+
     private void PlayerSpawn()
     {
         if (!PhotonNetwork.IsMasterClient)
@@ -55,10 +58,5 @@ public class TestBattleManager : MonoBehaviourPun
     private void RPC_SpawnTank(Vector3 spawnPos)
     {
         PhotonNetwork.Instantiate("Prefabs/Test Tank", spawnPos, Quaternion.identity);
-    }
-
-    private void PlayerAttacked()
-    {
-        _turnController.photonView.RPC("RPC_TurnFinished", RpcTarget.All, PhotonNetwork.LocalPlayer.ActorNumber);
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/Fire.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Fire.cs
@@ -34,6 +34,7 @@ public class Fire : MonoBehaviourPun
         //  이미 공격했다면 공격 불가능
         if (_playerController.IsAttacked)
             return;
+        //TODO : 턴 아닐 때 발사 제한 추가하기 
 
         // 스페이스바 누르고 있으면 차지 시작
         if (Input.GetKey(KeyCode.Space))

--- a/Assets/Workspace/MSK/MSK Scripts/Fire.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Fire.cs
@@ -18,10 +18,13 @@ public class Fire : MonoBehaviourPun
     private float powerCharge = 0f;         // 차지
     private bool isCharging = false;        // 차지 중인지 여부
 
+
+    private MSKTurnController _turnController;
     private PlayerController _playerController;
     private void Awake()
     {
         _playerController = GetComponentInParent<PlayerController>();
+        _turnController = FindObjectOfType<MSKTurnController>();
     }
 
 
@@ -79,7 +82,8 @@ public class Fire : MonoBehaviourPun
     private void Shoot()
     {
         GameObject bullet = PhotonNetwork.Instantiate("Prefabs/Projectile", firePoint.position, firePoint.rotation);
-
+        PhotonView bulletPhotonView = bullet.GetComponent<PhotonView>();
+        _turnController.photonView.RPC("RPC_SetBulletTarget", RpcTarget.All, bulletPhotonView.ViewID);
         Rigidbody2D rb = bullet.GetComponent<Rigidbody2D>();
         if (rb != null)
         {

--- a/Assets/Workspace/MSK/MSK Scripts/Fire.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Fire.cs
@@ -12,7 +12,7 @@ public class Fire : MonoBehaviourPun
     [Header("Controls")]
     [SerializeField] private float angle = 45f;         // 포신의 현재 각도
     [SerializeField] private float angleStep = 0.5f;      // 각도 변화량
-    [SerializeField] private float maxPower = 10f;         // 폭탄 발사 속도
+    [SerializeField] private float maxPower = 20f;         // 폭탄 발사 속도
     [SerializeField] private float chargingSpeed = 10f;    // 차지속도
 
     private float powerCharge = 0f;         // 차지
@@ -30,17 +30,17 @@ public class Fire : MonoBehaviourPun
         if (!photonView.IsMine)
             return;
 
+        if (!_playerController.isControllable)
+            return;
+
         Aim();
         //  이미 공격했다면 공격 불가능
         if (_playerController.IsAttacked)
             return;
-        //TODO : 턴 아닐 때 발사 제한 추가하기 
-
         // 스페이스바 누르고 있으면 차지 시작
         if (Input.GetKey(KeyCode.Space))
         {
             isCharging = true;
-            Debug.Log("차지");
             powerCharge += chargingSpeed * Time.deltaTime;
             powerCharge = Mathf.Clamp(powerCharge, 0f, maxPower);
         }
@@ -48,7 +48,6 @@ public class Fire : MonoBehaviourPun
         // 스페이스바에서 손을 뗐을 때 발사
         if (isCharging && Input.GetKeyUp(KeyCode.Space))
         {
-            Debug.Log($"발사, 힘 : {powerCharge}");
             Shoot();
             powerCharge = 0f;
             isCharging = false;

--- a/Assets/Workspace/MSK/MSK Scripts/MSKTestRoomManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/MSKTestRoomManager.cs
@@ -1,0 +1,25 @@
+using Photon.Pun;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Analytics;
+using UnityEngine.UI;
+
+public class MSKTestRoomManager : MonoBehaviour
+{
+    [Header("¹öÆ°")]
+    [SerializeField] private Button startButton;
+    private void Start()
+    {
+        startButton.onClick.AddListener(GameStart);
+    }
+    private void Awake()
+    {
+        PhotonNetwork.AutomaticallySyncScene = true;
+    }
+    public void GameStart()
+    {
+        if (PhotonNetwork.IsMasterClient)
+            PhotonNetwork.LoadLevel("MSK Test Scene");
+    }
+}

--- a/Assets/Workspace/MSK/MSK Scripts/MSKTestRoomManager.cs.meta
+++ b/Assets/Workspace/MSK/MSK Scripts/MSKTestRoomManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0265ab9c88f2b8439e9066fbc5f1f9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
@@ -1,4 +1,5 @@
 using Photon.Pun;
+using System;
 using TMPro;
 using UnityEngine;
 
@@ -17,6 +18,10 @@ public class PlayerController : MonoBehaviourPun
     private bool isControllable = false;
 
     public bool IsAttacked { get; private set; } = false;
+
+    public Action OnPlayerAttacked;
+    public Action OnPlayerDied;
+
     private void Awake()
     {
         //이동 가능한 거리를 이동 최대거리로 설정
@@ -33,10 +38,10 @@ public class PlayerController : MonoBehaviourPun
         //  닉네임 초기화
         _textMeshPro.text = photonView.IsMine ? PhotonNetwork.NickName : photonView.Owner.NickName;
     }
+
     private void FixedUpdate()
     {
         //  플레이어가 죽었거나, 내 플래이어가 아니라면 움직임 권한 박탈
-
         if (!photonView.IsMine)
             return;
         if (_isDead) 
@@ -88,8 +93,7 @@ public class PlayerController : MonoBehaviourPun
         IsAttacked = value;
         if (IsAttacked == true)
         {
-            //TODO : 턴 종료 타이밍 의논, 수정 가능성 (공격 종료시/ 탄 명중, 소멸시/)
-            //photonView.RPC("RPC_TurnFinished", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
+            OnPlayerAttacked?.Invoke();
         }
     }
 
@@ -99,16 +103,16 @@ public class PlayerController : MonoBehaviourPun
         Destroy(gameObject);
         photonView.RPC("RPC_PlayerDead", RpcTarget.All);
         _isDead = true;
-        // TODO : 턴 메니저에게 플레이어 죽음 사실은 전달하기
+        // TODO : 턴 메니저에게 플레이어 죽음 사실을 이벤트 전달하기
     }
 
     public void EnableControl(bool enable)
     {
+        Debug.Log($" {photonView.IsMine}, {PhotonNetwork.NickName}, {isControllable}");
         isControllable = enable;
         if (isControllable == true) 
         {
             ResetTurn();
         }
-    
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
@@ -11,7 +11,7 @@ public class PlayerController : MonoBehaviourPun
     [SerializeField] private Transform player;
     [SerializeField] private float _maxMove = 5f;  // 최대 이동거리
     [SerializeField] private int _hp = 100;         // hp
-
+    
     [SerializeField] private TextMeshProUGUI _textMeshPro;
     private float _movable;
     private bool _isDead = false;                   // 사망여부
@@ -83,8 +83,8 @@ public class PlayerController : MonoBehaviourPun
         _movable = 0;
         SetAttacked(true);
         isControllable = false;
-        Debug.Log("공격 & 움직임 불가능");
     }
+
     //  플레이어 재행동
     public void ResetTurn()
     {
@@ -92,14 +92,16 @@ public class PlayerController : MonoBehaviourPun
         _movable = _maxMove;
         SetAttacked(false);
         isControllable = true;
-        Debug.Log("공격 & 움직임 가능");
     }
 
     //  공격 가능 여부 바꿈
     public void SetAttacked(bool value)
     {
+        if (IsAttacked == value) return;
+
         IsAttacked = value;
-        if (IsAttacked == true)
+
+        if (IsAttacked)
         {
             OnPlayerAttacked?.Invoke();
             isControllable = false;
@@ -110,6 +112,7 @@ public class PlayerController : MonoBehaviourPun
     public void PlayerDead()
     {   
         Destroy(gameObject);
+        OnPlayerAttacked -= OnPlayerAttacked;
         photonView.RPC("RPC_PlayerDead", RpcTarget.All);
         _isDead = true;
         // TODO : 턴 메니저에게 플레이어 죽음 사실을 이벤트 전달하기

--- a/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
@@ -41,8 +41,8 @@ public class PlayerController : MonoBehaviourPun
             return;
         if (_isDead) 
             return;
-        //if (!isControllable)
-        //    return;
+        if (!isControllable)
+            return;
 
         // 이동 처리
         float horizontal = Input.GetAxisRaw("Horizontal");
@@ -88,7 +88,7 @@ public class PlayerController : MonoBehaviourPun
         IsAttacked = value;
         if (IsAttacked == true)
         {
-            //TODO : 턴 종료 타이밍 의논, 수정 가능성 (공격 종료시/ 탄 명중시/)
+            //TODO : 턴 종료 타이밍 의논, 수정 가능성 (공격 종료시/ 탄 명중, 소멸시/)
             //photonView.RPC("RPC_TurnFinished", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
         }
     }
@@ -105,5 +105,10 @@ public class PlayerController : MonoBehaviourPun
     public void EnableControl(bool enable)
     {
         isControllable = enable;
+        if (isControllable == true) 
+        {
+            ResetTurn();
+        }
+    
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
@@ -15,8 +15,7 @@ public class PlayerController : MonoBehaviourPun
     [SerializeField] private TextMeshProUGUI _textMeshPro;
     private float _movable;
     private bool _isDead = false;                   // 사망여부
-    private bool isControllable = false;
-
+    public bool isControllable { get; private set; } = false;
     public bool IsAttacked { get; private set; } = false;
 
     public Action OnPlayerAttacked;
@@ -78,12 +77,21 @@ public class PlayerController : MonoBehaviourPun
             PlayerDead();
     }
 
+    //  플레이어 턴 종료
+    public void EndPlayerTurn()
+    {
+        _movable = 0;
+        SetAttacked(true);
+        isControllable = false;
+        Debug.Log("공격 & 움직임 불가능");
+    }
     //  플레이어 재행동
     public void ResetTurn()
     {
         //이동 가능한 거리를 이동 최대거리로 설정
         _movable = _maxMove;
         SetAttacked(false);
+        isControllable = true;
         Debug.Log("공격 & 움직임 가능");
     }
 
@@ -94,6 +102,7 @@ public class PlayerController : MonoBehaviourPun
         if (IsAttacked == true)
         {
             OnPlayerAttacked?.Invoke();
+            isControllable = false;
         }
     }
 
@@ -108,11 +117,6 @@ public class PlayerController : MonoBehaviourPun
 
     public void EnableControl(bool enable)
     {
-        Debug.Log($" {photonView.IsMine}, {PhotonNetwork.NickName}, {isControllable}");
         isControllable = enable;
-        if (isControllable == true) 
-        {
-            ResetTurn();
-        }
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/Test.meta
+++ b/Assets/Workspace/MSK/MSK Scripts/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd2e0c4c5493d7f438898065db24ff3f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
@@ -1,0 +1,142 @@
+using Photon.Pun;
+using Photon.Realtime;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class MSKTurnController : MonoBehaviourPunCallbacks
+{
+    private Queue<PlayerInfo> turnQueue = new();
+    private List<PlayerInfo> nextCycle = new();
+    PlayerController[] tanks;
+    private UnityEvent OnGameEnded;
+    private PlayerInfo currentPlayer;
+    private Room room;
+
+    private void Start()
+    {
+        GameStart();
+    }
+    private void GameStart()
+    {
+        turnQueue.Clear();
+        nextCycle.Clear();
+        tanks = FindObjectsOfType<PlayerController>();
+
+        int playerCount = PhotonNetwork.CountOfPlayers;
+        room = PhotonNetwork.CurrentRoom;
+        // 추후 연계하여 조절
+        if (CustomProperty.GetTurnRandom(room))
+        {
+            List<int> randNumList = new();
+            for (int i = 0; i < playerCount; i++)
+            {
+                randNumList[i] = i + 1;
+            }
+            for (int i = playerCount - 1; i > 0; i--)
+            {
+                int index = Random.Range(0, i + 1);
+                int temp = randNumList[i];
+                randNumList[i] = randNumList[index];
+                randNumList[index] = temp;
+            }
+            for (int i = 0; i < playerCount; i++)
+            {
+                Player nowPlayer = PhotonNetwork.PlayerList[randNumList[i]];
+                turnQueue.Enqueue(new PlayerInfo(nowPlayer));
+            }
+        }
+        else
+        {
+            foreach (Player p in PhotonNetwork.PlayerList)
+            {
+                turnQueue.Enqueue(new PlayerInfo(p));
+            }
+        }
+
+        StartNextTurn();
+    }
+
+    private void StartNextTurn()
+    {
+        if (turnQueue.Count == 0)
+        {
+            if (nextCycle.Count <= 1)
+            {
+                Debug.Log("게임 종료");
+                photonView.RPC("RPC_GameEnded", RpcTarget.All, currentPlayer.ActorNumber);
+                return;
+            }
+            else
+            {
+                turnQueue = new Queue<PlayerInfo>(nextCycle);
+                nextCycle.Clear();
+            }
+        }
+
+        currentPlayer = turnQueue.Dequeue();
+
+        if (currentPlayer.isDead)
+        {
+            return;
+        }
+        photonView.RPC("StartTurnForPlayer", RpcTarget.All, currentPlayer.ActorNumber);
+    }
+
+    [PunRPC]
+    private void RPC_TurnFinished(int actorNumber)
+    {
+        if (currentPlayer != null && currentPlayer.ActorNumber == actorNumber)
+        {
+            nextCycle.Add(currentPlayer);
+            StartNextTurn();
+        }
+    }
+
+    [PunRPC]
+    private void RPC_GameEnded()
+    {
+        Debug.Log("게임 종료!");
+
+        // UI 교체
+        // 게임 오버 UI 출력
+        // Firebase에 게임 결과를 업로드
+    }
+
+    [PunRPC]
+    private void RPC_PlayerDead()
+    {
+        currentPlayer.isDead = true;
+    }
+
+    [PunRPC]
+    void StartTurnForPlayer(int actorNumber)
+    {
+        if (PhotonNetwork.LocalPlayer.ActorNumber == actorNumber)
+        {
+            Debug.Log("턴 시작");
+            EnableCurrentPlayer();
+        }
+    }
+
+    void EnableCurrentPlayer()
+    {
+
+        foreach (PlayerController player in tanks)
+        {
+            PhotonView view = player.GetComponent<PhotonView>();
+            if (view != null && view.Owner != null)
+            {
+                if (view.Owner.ActorNumber == currentPlayer.ActorNumber)
+                {
+                    player.EnableControl(true);
+                }
+                else
+                {
+                    player.EnableControl(false);
+                }
+            }
+        }
+    }
+
+}

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
@@ -13,25 +13,28 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
     private PlayerInfo currentPlayer;
     private Room room;
 
-    private void Start()
-    {
-        GameStart();
-    }
-    private void GameStart()
+    public void GameStart()
     {
         turnQueue.Clear();
         nextCycle.Clear();
         tanks = FindObjectsOfType<PlayerController>();
 
+        foreach (var tank in tanks)
+        {
+            PhotonView view = tank.GetComponent<PhotonView>();
+            string owner = view != null && view.Owner != null ? view.Owner.NickName : "null";
+            Debug.Log($"탱크 발견 - 닉네임: {owner}, ActorNumber: {view?.Owner?.ActorNumber}");
+        }
+
         int playerCount = PhotonNetwork.CountOfPlayers;
         room = PhotonNetwork.CurrentRoom;
-        // 추후 연계하여 조절
+
         if (CustomProperty.GetTurnRandom(room))
         {
             List<int> randNumList = new();
             for (int i = 0; i < playerCount; i++)
             {
-                randNumList[i] = i + 1;
+                randNumList.Add(i + 1);
             }
             for (int i = playerCount - 1; i > 0; i--)
             {
@@ -40,6 +43,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
                 randNumList[i] = randNumList[index];
                 randNumList[index] = temp;
             }
+
             for (int i = 0; i < playerCount; i++)
             {
                 Player nowPlayer = PhotonNetwork.PlayerList[randNumList[i]];
@@ -50,6 +54,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
         {
             foreach (Player p in PhotonNetwork.PlayerList)
             {
+                Debug.Log($"기본 순서 플레이어 추가: ActorNumber={p.ActorNumber}");
                 turnQueue.Enqueue(new PlayerInfo(p));
             }
         }
@@ -59,11 +64,13 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
 
     private void StartNextTurn()
     {
+        Debug.Log($"StartNextTurn 호출 - 남은 플레이어 수: {turnQueue.Count}");
+
         if (turnQueue.Count == 0)
         {
+            Debug.Log($"턴 큐 비었음, 다음 사이클 플레이어 수: {nextCycle.Count}");
             if (nextCycle.Count <= 1)
             {
-                Debug.Log("게임 종료");
                 photonView.RPC("RPC_GameEnded", RpcTarget.All, currentPlayer.ActorNumber);
                 return;
             }
@@ -71,24 +78,37 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
             {
                 turnQueue = new Queue<PlayerInfo>(nextCycle);
                 nextCycle.Clear();
+                Debug.Log("다음 사이클로 턴 큐 갱신");
             }
         }
 
         currentPlayer = turnQueue.Dequeue();
+        Debug.Log($"현재 턴 플레이어: ActorNumber={currentPlayer.ActorNumber}, isDead={currentPlayer.isDead}");
 
         if (currentPlayer.isDead)
         {
+            Debug.Log($"플레이어 {currentPlayer.ActorNumber} 사망 상태, 다음 턴으로 이동");
+            StartNextTurn();
             return;
         }
         photonView.RPC("StartTurnForPlayer", RpcTarget.All, currentPlayer.ActorNumber);
     }
 
     [PunRPC]
+    public void RPC_Spawned()
+    {
+        Debug.Log("게임 시작");
+        GameStart();
+    }
+
+    [PunRPC]
     private void RPC_TurnFinished(int actorNumber)
     {
+        Debug.Log($"RPC_TurnFinished 호출: ActorNumber={actorNumber}");
         if (currentPlayer != null && currentPlayer.ActorNumber == actorNumber)
         {
             nextCycle.Add(currentPlayer);
+            Debug.Log($"플레이어 {actorNumber} 턴 종료, nextCycle에 추가됨");
             StartNextTurn();
         }
     }
@@ -97,31 +117,29 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
     private void RPC_GameEnded()
     {
         Debug.Log("게임 종료!");
-
-        // UI 교체
-        // 게임 오버 UI 출력
-        // Firebase에 게임 결과를 업로드
     }
 
     [PunRPC]
     private void RPC_PlayerDead()
     {
+        Debug.Log($"플레이어 {currentPlayer.ActorNumber} 사망 처리");
         currentPlayer.isDead = true;
     }
 
     [PunRPC]
     void StartTurnForPlayer(int actorNumber)
     {
+        Debug.Log($"StartTurnForPlayer 호출: ActorNumber={actorNumber}, LocalPlayer={PhotonNetwork.LocalPlayer.ActorNumber}");
         if (PhotonNetwork.LocalPlayer.ActorNumber == actorNumber)
         {
-            Debug.Log("턴 시작");
+            Debug.Log("내 턴 시작");
             EnableCurrentPlayer();
         }
     }
 
     void EnableCurrentPlayer()
     {
-
+        Debug.Log("EnableCurrentPlayer 호출");
         foreach (PlayerController player in tanks)
         {
             PhotonView view = player.GetComponent<PhotonView>();
@@ -129,6 +147,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
             {
                 if (view.Owner.ActorNumber == currentPlayer.ActorNumber)
                 {
+                    Debug.Log($"플레이어 {currentPlayer.ActorNumber} 컨트롤 활성화");
                     player.EnableControl(true);
                 }
                 else
@@ -138,5 +157,6 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
             }
         }
     }
+
 
 }

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
@@ -81,6 +81,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
             StartNextTurn();
             return;
         }
+        photonView.RPC("RPC_SetCameraTarget", RpcTarget.All, currentPlayer.ActorNumber);
         photonView.RPC("StartTurnForPlayer", RpcTarget.All, currentPlayer.ActorNumber);
     }
 
@@ -118,6 +119,34 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
         if (PhotonNetwork.LocalPlayer.ActorNumber == actorNumber)
         {
             EnableCurrentPlayer();
+        }
+    }
+
+    [PunRPC]
+    void RPC_SetCameraTarget(int actorNumber)
+    {
+        tanks = FindObjectsOfType<PlayerController>();
+        // 턴 플레이어 찾기
+        foreach (var player in tanks)
+        {
+            PhotonView view = player.GetComponent<PhotonView>();
+            if (view != null && view.Owner != null && view.Owner.ActorNumber == actorNumber)
+            {
+                CameraController.Instance.vcamPlayer.Follow = player.transform;
+                CameraController.Instance.vcamPlayer.Priority = 20;
+                break;
+            }
+        }
+    }
+
+    [PunRPC]
+    void RPC_SetBulletTarget(int bulletViewID)
+    {
+        PhotonView bulletView = PhotonView.Find(bulletViewID);
+        if (bulletView != null)
+        {
+            CameraController.Instance.vcamBullet.Follow = bulletView.transform;
+            CameraController.Instance.vcamBullet.Priority = 20;
         }
     }
 

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs.meta
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93044c97b1805d24cbdefc9d6b9b95a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/MSK Scripts/TestNetworkManager.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/TestNetworkManager.cs
@@ -6,21 +6,32 @@ using UnityEngine;
 
 public class TestNetworkManager : MonoBehaviourPunCallbacks
 {
-    [SerializeField] private Transform _spawnPoint;
+    public static TestNetworkManager Instance { get; private set; }
 
     [SerializeField] private string _roomName;
+
+    private void Awake()
+    {
+        // 싱글톤 중복 방지
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
 
     private void Start()
     {
         PhotonNetwork.ConnectUsingSettings();
     }
 
-    //  테스트 용도이기 때문에 즉시 연결
     public override void OnConnectedToMaster()
     {
         PhotonNetwork.JoinOrCreateRoom(_roomName, new RoomOptions(), TypedLobby.Default);
     }
-
+    
     public override void OnCreatedRoom() { }
 
     // 방 입장 시
@@ -29,9 +40,6 @@ public class TestNetworkManager : MonoBehaviourPunCallbacks
         Debug.Log("TestNetworkManager : OnJoinedRoom, 입장 완료");
         //  닉네임을 플레이어 번호로 대체
         PhotonNetwork.LocalPlayer.NickName = $"Player_{PhotonNetwork.LocalPlayer.ActorNumber}";
-
-        // PC 스폰
-        PlayerSpawn();
     }
 
     public override void OnMasterClientSwitched(Player newMasterClient)
@@ -41,21 +49,6 @@ public class TestNetworkManager : MonoBehaviourPunCallbacks
         }
     }
 
-    private IEnumerator MonsterSpawn()
-    {
-        while (true)
-        {
-            yield return new WaitForSeconds(2f);
-        }
-    }
-
-    //  플레이어 스폰
-    private void PlayerSpawn()
-    {
-        // 프폰 포인트 중복되지 않게 리스트에서 랜덤하게 생성
-        Vector3 spawnPos = _spawnPoint.position;
-        PhotonNetwork.Instantiate("Prefabs/Test Tank", spawnPos, Quaternion.identity);
-    }
 
     public override void OnPlayerEnteredRoom(Player player)
     {

--- a/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor1.mat
+++ b/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor1.mat
@@ -1,0 +1,148 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-517136058837915236
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TeamColor1
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnableExternalAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0, b: 0.15028906, a: 1}
+    - _Color: {r: 1, g: 0, b: 0.15028903, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor1.mat.meta
+++ b/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29ede1e719246ef4f89c03641828a0b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor2.mat
+++ b/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor2.mat
@@ -1,0 +1,148 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-517136058837915236
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TeamColor2
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnableExternalAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0.7415495, b: 1, a: 1}
+    - _Color: {r: 0, g: 0.74154943, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor2.mat.meta
+++ b/Assets/Workspace/MSK/MSK TestPrefabs/TeamColor2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be7896554a9a4434f8faa2528ae95c46
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
@@ -201,6 +201,7 @@ GameObject:
   - component: {fileID: 550839521}
   - component: {fileID: 550839520}
   - component: {fileID: 550839519}
+  - component: {fileID: 550839522}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -282,6 +283,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &550839522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550839518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!1 &556795854
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
@@ -1,0 +1,740 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &125515036
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 125515039}
+  - component: {fileID: 125515038}
+  - component: {fileID: 125515037}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &125515037
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 125515036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &125515038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 125515036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &125515039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 125515036}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &550839518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 550839521}
+  - component: {fileID: 550839520}
+  - component: {fileID: 550839519}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &550839519
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550839518}
+  m_Enabled: 1
+--- !u!20 &550839520
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550839518}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &550839521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 550839518}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &556795854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 556795856}
+  - component: {fileID: 556795855}
+  m_Layer: 0
+  m_Name: TestRoom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &556795855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 556795854}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0265ab9c88f2b8439e9066fbc5f1f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startButton: {fileID: 869895031}
+--- !u!4 &556795856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 556795854}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7.958886, y: 2.4808145, z: -10.14621}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &643058762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 643058763}
+  - component: {fileID: 643058766}
+  - component: {fileID: 643058765}
+  - component: {fileID: 643058764}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &643058763
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643058762}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 869895034}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &643058764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643058762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &643058765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643058762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &643058766
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643058762}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &869895030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 869895034}
+  - component: {fileID: 869895033}
+  - component: {fileID: 869895032}
+  - component: {fileID: 869895031}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &869895031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869895030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 869895032}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &869895032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869895030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &869895033
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869895030}
+  m_CullTransparentMesh: 1
+--- !u!224 &869895034
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 869895030}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1106522019}
+  m_Father: {fileID: 643058763}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1106522018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1106522019}
+  - component: {fileID: 1106522021}
+  - component: {fileID: 1106522020}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1106522019
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106522018}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 869895034}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1106522020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106522018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Button
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1106522021
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106522018}
+  m_CullTransparentMesh: 1
+--- !u!1 &1571966854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1571966856}
+  - component: {fileID: 1571966855}
+  m_Layer: 0
+  m_Name: TestNetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1571966855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1571966854}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a40043d5e1180994ab1f482d06efce97, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _roomName: TestRoom1234
+--- !u!4 &1571966856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1571966854}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.022901, y: 1.0821549, z: -0.070258744}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 550839521}
+  - {fileID: 1571966856}
+  - {fileID: 643058763}
+  - {fileID: 125515039}
+  - {fileID: 556795856}

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity
@@ -758,7 +758,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a40043d5e1180994ab1f482d06efce97, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _roomName: TestRoom1234
+  _roomName: TestRoom12345
 --- !u!4 &1571966856
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity.meta
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Lobby.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e3d7a5055b4472429541d9d5af6df3c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -805,6 +805,41 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &861246726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 861246727}
+  m_Layer: 0
+  m_Name: Spawn Point List
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &861246727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861246726}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7.958886, y: 2.4808145, z: -10.14621}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1269334165}
+  - {fileID: 1973986414}
+  - {fileID: 1946933577}
+  - {fileID: 1943316881}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1040329384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1022,12 +1057,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1269334164}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -13.08, y: -1.8, z: -0.070258744}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -5.121114, y: -4.280814, z: 10.075951}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 861246727}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1392346344
 GameObject:
@@ -1131,6 +1166,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1495371541}
   - component: {fileID: 1495371542}
+  - component: {fileID: 1495371543}
   m_Layer: 0
   m_Name: TestNetworkManager
   m_TagString: Untagged
@@ -1165,8 +1201,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3ededb9452c34934c9cab01b24d36ad8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _spawnPoint: []
+  _spawnPoint:
+  - {fileID: 1269334165}
+  - {fileID: 1973986414}
+  - {fileID: 1946933577}
+  - {fileID: 1943316881}
   _turnEndButton: {fileID: 1190335539}
+--- !u!114 &1495371543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1495371539}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 1
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1602292647
 GameObject:
   m_ObjectHideFlags: 0
@@ -1597,6 +1659,99 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1943316880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1943316881}
+  m_Layer: 0
+  m_Name: SpownPoint (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1943316881
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943316880}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 20.2, y: -5.1, z: 10.075951}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 861246727}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1946933576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1946933577}
+  m_Layer: 0
+  m_Name: SpownPoint (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1946933577
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1946933576}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 25.9, y: -5, z: 10.075951}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 861246727}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1973986413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1973986414}
+  m_Layer: 0
+  m_Name: SpownPoint (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1973986414
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1973986413}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.9, y: -4.5, z: 10.075951}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 861246727}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2005791461
 GameObject:
   m_ObjectHideFlags: 0
@@ -1804,7 +1959,7 @@ Transform:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1269334165}
+  - {fileID: 861246727}
   - {fileID: 543830121}
   - {fileID: 1392346346}
   - {fileID: 1940834581}

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -770,7 +770,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 828588925}
-  - component: {fileID: 828588924}
+  - component: {fileID: 828588926}
   m_Layer: 0
   m_Name: TurnController
   m_TagString: Untagged
@@ -778,18 +778,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &828588924
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 828588923}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 777fc099bb5cf2948b8bfa8c80ab4098, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &828588925
 Transform:
   m_ObjectHideFlags: 0
@@ -805,6 +793,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &828588926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828588923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93044c97b1805d24cbdefc9d6b9b95a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &861246726
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -1131,7 +1131,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1495371541}
   - component: {fileID: 1495371542}
-  - component: {fileID: 1495371543}
   m_Layer: 0
   m_Name: TestNetworkManager
   m_TagString: Untagged
@@ -1166,21 +1165,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3ededb9452c34934c9cab01b24d36ad8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _spawnPoint: []
   _turnEndButton: {fileID: 1190335539}
---- !u!114 &1495371543
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1495371539}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a40043d5e1180994ab1f482d06efce97, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _spawnPoint: {fileID: 1269334165}
-  _roomName: TestRoom1234
 --- !u!1 &1602292647
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -1505,6 +1505,178 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1940750086}
   m_CullTransparentMesh: 1
+--- !u!1 &2005791461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2005791466}
+  - component: {fileID: 2005791465}
+  - component: {fileID: 2005791464}
+  - component: {fileID: 2005791463}
+  - component: {fileID: 2005791462}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2005791462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005791461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2005791463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005791461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &2005791464
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005791461}
+  m_Enabled: 1
+--- !u!20 &2005791465
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005791461}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5.69
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2005791466
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2005791461}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -14.37, y: -0.6, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1519,3 +1691,4 @@ SceneRoots:
   - {fileID: 1040329386}
   - {fileID: 1854198339}
   - {fileID: 1602292649}
+  - {fileID: 2005791466}

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -806,7 +806,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 93044c97b1805d24cbdefc9d6b9b95a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  turnLimit: 5
 --- !u!114 &828588927
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -858,9 +857,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1269334165}
   - {fileID: 1973986414}
-  - {fileID: 1946933577}
   - {fileID: 1943316881}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1057,37 +1054,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1190335537}
   m_CullTransparentMesh: 1
---- !u!1 &1269334164
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1269334165}
-  m_Layer: 0
-  m_Name: SpownPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1269334165
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1269334164}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -5.121114, y: -4.280814, z: 10.075951}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 861246727}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1392346344
 GameObject:
   m_ObjectHideFlags: 0
@@ -1226,9 +1192,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _spawnPoint:
-  - {fileID: 1269334165}
   - {fileID: 1973986414}
-  - {fileID: 1946933577}
   - {fileID: 1943316881}
   _turnEndButton: {fileID: 1190335539}
   _turnController: {fileID: 828588926}
@@ -1710,37 +1674,6 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 20.2, y: -5.1, z: 10.075951}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 861246727}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1946933576
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1946933577}
-  m_Layer: 0
-  m_Name: SpownPoint (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1946933577
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1946933576}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 25.9, y: -5, z: 10.075951}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -771,6 +771,7 @@ GameObject:
   m_Component:
   - component: {fileID: 828588925}
   - component: {fileID: 828588926}
+  - component: {fileID: 828588927}
   m_Layer: 0
   m_Name: TurnController
   m_TagString: Untagged
@@ -805,6 +806,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 93044c97b1805d24cbdefc9d6b9b95a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &828588927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828588923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 2
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &861246726
 GameObject:
   m_ObjectHideFlags: 0
@@ -1207,6 +1230,7 @@ MonoBehaviour:
   - {fileID: 1946933577}
   - {fileID: 1943316881}
   _turnEndButton: {fileID: 1190335539}
+  _turnController: {fileID: 828588926}
 --- !u!114 &1495371543
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -122,6 +122,196 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &53218990
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 53218991}
+  - component: {fileID: 53218994}
+  - component: {fileID: 53218993}
+  - component: {fileID: 53218992}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &53218991
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53218990}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1715897062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &53218992
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53218990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+--- !u!114 &53218993
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53218990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &53218994
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53218990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &399238260
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 399238261}
+  - component: {fileID: 399238264}
+  - component: {fileID: 399238263}
+  - component: {fileID: 399238262}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &399238261
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399238260}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1040329386}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &399238262
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399238260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_BindingMode: 1
+  m_FollowOffset: {x: 0, y: 0, z: -10}
+  m_XDamping: 0.1
+  m_YDamping: 0.1
+  m_ZDamping: 0.1
+  m_AngularDampingMode: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AngularDamping: 0
+--- !u!114 &399238263
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399238260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &399238264
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399238260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &512760091
 GameObject:
   m_ObjectHideFlags: 0
@@ -188,6 +378,428 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &543830119
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 543830121}
+  - component: {fileID: 543830120}
+  - component: {fileID: 543830122}
+  - component: {fileID: 543830123}
+  m_Layer: 0
+  m_Name: map
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &543830120
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543830119}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 84a5a82440cd91048bd1d61b2631d789, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 38.399998, y: 21.599998}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &543830121
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543830119}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.42, y: -1.73, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!60 &543830122
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543830119}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 38.399998, y: 21.599998}
+    newSize: {x: 38.399998, y: 21.599998}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -3.1499999, y: -10.0125}
+      - {x: -3.0187497, y: -9.674999}
+      - {x: -2.9624999, y: -9.487499}
+      - {x: -2.9062498, y: -9.16875}
+      - {x: -2.9062498, y: -8.5125}
+      - {x: -2.9249997, y: -8.381249}
+      - {x: -2.94375, y: -8.287499}
+      - {x: -2.9999998, y: -8.04375}
+      - {x: -3.0937498, y: -7.7812495}
+      - {x: -3.225, y: -7.4812493}
+      - {x: -3.3374999, y: -7.3124995}
+      - {x: -3.4499998, y: -7.1624994}
+      - {x: -3.4499998, y: -6.6562495}
+      - {x: -3.4874997, y: -6.3749995}
+      - {x: -3.6, y: -5.8499994}
+      - {x: -3.6562498, y: -5.6624994}
+      - {x: -3.6937497, y: -5.56875}
+      - {x: -3.8812497, y: -5.1562495}
+      - {x: -3.9749997, y: -5.00625}
+      - {x: -4.1437497, y: -4.7812495}
+      - {x: -4.5187497, y: -4.4249997}
+      - {x: -4.6874995, y: -4.29375}
+      - {x: -4.9312496, y: -4.1249995}
+      - {x: -5.2124996, y: -3.9749997}
+      - {x: -5.60625, y: -3.7687497}
+      - {x: -5.8875, y: -3.5437498}
+      - {x: -6.3187494, y: -3.2812498}
+      - {x: -6.6375, y: -3.13125}
+      - {x: -7.0874996, y: -2.9249997}
+      - {x: -7.2, y: -2.8874998}
+      - {x: -7.5749993, y: -2.7749999}
+      - {x: -8.156249, y: -2.5874999}
+      - {x: -8.41875, y: -2.5312498}
+      - {x: -8.7, y: -2.475}
+      - {x: -8.8875, y: -2.4187498}
+      - {x: -9.018749, y: -2.3625}
+      - {x: -9.487499, y: -2.3062499}
+      - {x: -9.9, y: -2.26875}
+      - {x: -10.36875, y: -2.2499998}
+      - {x: -10.65, y: -2.2124999}
+      - {x: -10.8375, y: -2.19375}
+      - {x: -13.856249, y: -2.19375}
+      - {x: -14.043749, y: -2.2124999}
+      - {x: -14.174999, y: -2.2312498}
+      - {x: -14.512499, y: -2.2875}
+      - {x: -14.906249, y: -2.3249998}
+      - {x: -15.337499, y: -2.38125}
+      - {x: -15.449999, y: -2.3999999}
+      - {x: -16.162498, y: -2.56875}
+      - {x: -16.349998, y: -2.6249998}
+      - {x: -16.631248, y: -2.6625}
+      - {x: -16.818748, y: -2.6999998}
+      - {x: -17.11875, y: -2.7749999}
+      - {x: -17.437498, y: -2.8312497}
+      - {x: -17.624998, y: -2.8687499}
+      - {x: -17.999998, y: -2.9624999}
+      - {x: -18.281248, y: -2.9999998}
+      - {x: -18.449999, y: -3.0375}
+      - {x: -19.199999, y: -3.1874998}
+      - {x: -19.199999, y: -10.799999}
+      - {x: -3.6562498, y: -10.799999}
+      - {x: -3.6374998, y: -10.781249}
+      - {x: -3.3749998, y: -10.424999}
+      - {x: -3.2812498, y: -10.275}
+    - - {x: 18.7125, y: -3.6749997}
+      - {x: 18.037498, y: -3.3562498}
+      - {x: 17.793749, y: -3.2624998}
+      - {x: 17.662498, y: -3.225}
+      - {x: 17.193748, y: -3.0749998}
+      - {x: 17.006248, y: -3.0562499}
+      - {x: 16.724998, y: -3.0187497}
+      - {x: 16.4625, y: -2.9812498}
+      - {x: 16.05, y: -2.9249997}
+      - {x: 15.843749, y: -2.9062498}
+      - {x: 15.318749, y: -2.9062498}
+      - {x: 15.299999, y: -2.8874998}
+      - {x: 14.737499, y: -2.7749999}
+      - {x: 14.568749, y: -2.7375}
+      - {x: 14.324999, y: -2.6999998}
+      - {x: 13.612499, y: -2.6062498}
+      - {x: 13.4625, y: -2.5874999}
+      - {x: 12.43125, y: -2.5874999}
+      - {x: 12.018749, y: -2.6062498}
+      - {x: 11.86875, y: -2.6249998}
+      - {x: 11.68125, y: -2.6625}
+      - {x: 11.474999, y: -2.7187498}
+      - {x: 11.099999, y: -2.85}
+      - {x: 9.393749, y: -2.85}
+      - {x: 9.15, y: -2.8687499}
+      - {x: 8.5875, y: -2.94375}
+      - {x: 8.41875, y: -2.9812498}
+      - {x: 8.268749, y: -3.0187497}
+      - {x: 7.9124994, y: -3.1124997}
+      - {x: 7.6499996, y: -3.2062497}
+      - {x: 7.1437497, y: -3.4312499}
+      - {x: 6.8437495, y: -3.5812497}
+      - {x: 6.4687495, y: -3.8249998}
+      - {x: 6.2062497, y: -4.0125}
+      - {x: 5.8875, y: -4.3124995}
+      - {x: 5.4937496, y: -4.7062497}
+      - {x: 5.38125, y: -4.85625}
+      - {x: 5.2124996, y: -5.1}
+      - {x: 5.0812497, y: -5.38125}
+      - {x: 4.8937497, y: -5.8499994}
+      - {x: 4.81875, y: -6.075}
+      - {x: 4.7625, y: -6.2062497}
+      - {x: 4.725, y: -6.54375}
+      - {x: 4.725, y: -7.1624994}
+      - {x: 4.7437496, y: -7.2937493}
+      - {x: 4.81875, y: -7.7062497}
+      - {x: 5.00625, y: -8.268749}
+      - {x: 5.19375, y: -8.624999}
+      - {x: 5.325, y: -8.831249}
+      - {x: 5.8499994, y: -9.506249}
+      - {x: 5.9999995, y: -9.674999}
+      - {x: 6.35625, y: -10.068749}
+      - {x: 6.6749997, y: -10.36875}
+      - {x: 6.8812494, y: -10.518749}
+      - {x: 7.2562494, y: -10.781249}
+      - {x: 7.2749996, y: -10.799999}
+      - {x: 19.199999, y: -10.799999}
+      - {x: 19.199999, y: -3.9937499}
+    - - {x: 9.974999, y: 1.4812499}
+      - {x: 10.349999, y: 1.5937499}
+      - {x: 10.518749, y: 1.6312499}
+      - {x: 10.66875, y: 1.6687499}
+      - {x: 11.268749, y: 1.8937498}
+      - {x: 11.512499, y: 1.9499999}
+      - {x: 11.849999, y: 2.08125}
+      - {x: 11.999999, y: 2.1187499}
+      - {x: 12.43125, y: 2.3625}
+      - {x: 12.599999, y: 2.4937499}
+      - {x: 12.787499, y: 2.6625}
+      - {x: 12.9, y: 2.75625}
+      - {x: 13.068749, y: 2.9812498}
+      - {x: 13.143749, y: 3.0749998}
+      - {x: 13.312499, y: 3.4312499}
+      - {x: 13.36875, y: 3.6}
+      - {x: 13.424999, y: 3.8624997}
+      - {x: 13.443749, y: 4.0874996}
+      - {x: 13.443749, y: 4.29375}
+      - {x: 13.406249, y: 4.5375}
+      - {x: 13.36875, y: 4.7062497}
+      - {x: 13.293749, y: 4.9312496}
+      - {x: 13.162499, y: 5.19375}
+      - {x: 12.99375, y: 5.4562497}
+      - {x: 12.637499, y: 5.79375}
+      - {x: 12.374999, y: 5.9437494}
+      - {x: 12.093749, y: 6.075}
+      - {x: 11.924999, y: 6.1499996}
+      - {x: 11.099999, y: 6.5062494}
+      - {x: 10.912499, y: 6.54375}
+      - {x: 10.406249, y: 6.6562495}
+      - {x: 10.143749, y: 6.6937494}
+      - {x: 9.693749, y: 6.73125}
+      - {x: 9.581249, y: 6.7687497}
+      - {x: 9.299999, y: 6.8062496}
+      - {x: 8.737499, y: 6.7874994}
+      - {x: 8.718749, y: 6.8062496}
+      - {x: 8.4, y: 6.8812494}
+      - {x: 8.1375, y: 6.9937496}
+      - {x: 7.8374996, y: 7.1249995}
+      - {x: 7.5937495, y: 7.1812496}
+      - {x: 7.4249997, y: 7.2187495}
+      - {x: 6.8999996, y: 7.2187495}
+      - {x: 6.5624995, y: 7.1624994}
+      - {x: 6.2999997, y: 7.1437497}
+      - {x: 6.075, y: 7.10625}
+      - {x: 5.7374997, y: 7.0312495}
+      - {x: 5.5499997, y: 6.9749994}
+      - {x: 5.1, y: 6.8812494}
+      - {x: 4.81875, y: 6.8437495}
+      - {x: 4.3687496, y: 6.6937494}
+      - {x: 4.0874996, y: 6.5624995}
+      - {x: 3.8437498, y: 6.4874997}
+      - {x: 3.4687498, y: 6.3374996}
+      - {x: 2.9812498, y: 6.0937495}
+      - {x: 2.8124998, y: 6.0187497}
+      - {x: 2.3999999, y: 5.8312497}
+      - {x: 2.2875, y: 5.7562494}
+      - {x: 1.9312499, y: 5.475}
+      - {x: 1.5937499, y: 5.1375}
+      - {x: 1.4812499, y: 4.9687495}
+      - {x: 1.275, y: 4.4999995}
+      - {x: 1.2562499, y: 4.3312497}
+      - {x: 1.2187499, y: 4.0312495}
+      - {x: 1.2187499, y: 3.7874997}
+      - {x: 1.2562499, y: 3.4125}
+      - {x: 1.36875, y: 3.1499999}
+      - {x: 1.4812499, y: 2.9062498}
+      - {x: 1.6874999, y: 2.5124998}
+      - {x: 1.8374999, y: 2.3249998}
+      - {x: 2.19375, y: 1.9874998}
+      - {x: 2.6625, y: 1.7437499}
+      - {x: 2.9624999, y: 1.6125}
+      - {x: 3.3749998, y: 1.4999999}
+      - {x: 3.6937497, y: 1.425}
+      - {x: 3.8812497, y: 1.3874999}
+      - {x: 4.2187495, y: 1.3499999}
+      - {x: 4.44375, y: 1.33125}
+      - {x: 4.7999997, y: 1.275}
+      - {x: 5.0249996, y: 1.2562499}
+      - {x: 5.325, y: 1.2375}
+      - {x: 5.4374995, y: 1.2187499}
+      - {x: 8.662499, y: 1.2187499}
+      - {x: 8.999999, y: 1.275}
+      - {x: 9.187499, y: 1.3124999}
+  m_UseDelaunayMesh: 0
+--- !u!114 &543830123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 543830119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 28d29b35d3fb7d34e81738b4f10b7687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1040329384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1040329386}
+  - component: {fileID: 1040329385}
+  m_Layer: 0
+  m_Name: Virtual Camera Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1040329385
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040329384}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 5
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5.69
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 399238261}
+--- !u!4 &1040329386
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040329384}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -14.37, y: -0.6, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 399238261}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1190335537
@@ -336,12 +948,104 @@ Transform:
   m_GameObject: {fileID: 1269334164}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.51, y: 2.38, z: -0.070258744}
+  m_LocalPosition: {x: -13.08, y: -1.8, z: -0.070258744}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1392346344
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1392346346}
+  - component: {fileID: 1392346345}
+  - component: {fileID: 1392346347}
+  m_Layer: 0
+  m_Name: MapBoundary
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1392346345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392346344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ad9679a91b2b1e49bdba7dbc015b479, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mapSpriteRenderer: {fileID: 0}
+  padding: 2
+--- !u!4 &1392346346
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392346344}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.9146495, y: 0.92158884, z: -0.1600304}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1392346347
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392346344}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1495371539
 GameObject:
   m_ObjectHideFlags: 0
@@ -402,7 +1106,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _spawnPoint: {fileID: 1269334165}
   _roomName: TestRoom1234
---- !u!1 &1619051848
+--- !u!1 &1602292647
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -410,260 +1114,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1619051850}
-  - component: {fileID: 1619051849}
-  - component: {fileID: 1619051851}
-  - component: {fileID: 1619051852}
+  - component: {fileID: 1602292649}
+  - component: {fileID: 1602292648}
   m_Layer: 0
-  m_Name: aas vasdfsav
+  m_Name: MapManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &1619051849
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619051848}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: a7458af4e6981cf4b9b5940e4e5230ab, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 10, y: 5}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1619051850
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619051848}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.65, y: -1.41, z: 0}
-  m_LocalScale: {x: 1.4138, y: 1.6076, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1619051851
+--- !u!114 &1602292648
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619051848}
+  m_GameObject: {fileID: 1602292647}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 28d29b35d3fb7d34e81738b4f10b7687, type: 3}
+  m_Script: {fileID: 11500000, guid: de6db06e12ed60640b1f70f020e22ef9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!60 &1619051852
-PolygonCollider2D:
+  mapSpriteRenderer: {fileID: 543830120}
+--- !u!4 &1602292649
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1619051848}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 10, y: 5}
-    newSize: {x: 10, y: 5}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Points:
-    m_Paths:
-    - - {x: -0.21, y: -1.93}
-      - {x: 0.04, y: -1.91}
-      - {x: 0.45999998, y: -1.87}
-      - {x: 0.65999997, y: -1.8299999}
-      - {x: 0.91999996, y: -1.77}
-      - {x: 1.04, y: -1.7099999}
-      - {x: 1.12, y: -1.75}
-      - {x: 1.27, y: -1.8}
-      - {x: 1.3299999, y: -1.81}
-      - {x: 1.65, y: -1.81}
-      - {x: 1.73, y: -1.77}
-      - {x: 1.8299999, y: -1.66}
-      - {x: 1.88, y: -1.5799999}
-      - {x: 1.9499999, y: -1.43}
-      - {x: 1.9799999, y: -1.3}
-      - {x: 2.1, y: -0.94}
-      - {x: 2.1299999, y: -0.84}
-      - {x: 2.19, y: -0.21}
-      - {x: 2.24, y: 0.14999999}
-      - {x: 2.27, y: 0.25}
-      - {x: 2.3899999, y: 0.26}
-      - {x: 2.75, y: 0.35}
-      - {x: 2.85, y: 0.38}
-      - {x: 3, y: 0.45}
-      - {x: 2.99, y: 0.19999999}
-      - {x: 2.96, y: -0.07}
-      - {x: 2.96, y: -0.71999997}
-      - {x: 2.98, y: -1.05}
-      - {x: 3, y: -1.29}
-      - {x: 3.05, y: -1.41}
-      - {x: 3.11, y: -1.49}
-      - {x: 3.1799998, y: -1.55}
-      - {x: 3.29, y: -1.61}
-      - {x: 3.36, y: -1.64}
-      - {x: 3.49, y: -1.6899999}
-      - {x: 3.81, y: -1.68}
-      - {x: 3.85, y: -1.63}
-      - {x: 3.9199998, y: -1.5}
-      - {x: 3.9599998, y: -1.36}
-      - {x: 3.98, y: -0.94}
-      - {x: 4.02, y: -0.51}
-      - {x: 4.04, y: 0}
-      - {x: 4.0699997, y: 0.22999999}
-      - {x: 4.13, y: 0.48}
-      - {x: 4.2799997, y: 0.89}
-      - {x: 4.33, y: 1.04}
-      - {x: 4.33, y: 1.18}
-      - {x: 4.25, y: 1.24}
-      - {x: 4.0499997, y: 1.25}
-      - {x: 3.08, y: 1.25}
-      - {x: 2.81, y: 1.23}
-      - {x: 2.47, y: 1.2099999}
-      - {x: 2.01, y: 1.1999999}
-      - {x: 1.78, y: 1.15}
-      - {x: 1.73, y: 1.12}
-      - {x: 1.61, y: 1}
-      - {x: 1.53, y: 0.88}
-      - {x: 1.38, y: 0.59999996}
-      - {x: 1.23, y: 0.26999998}
-      - {x: 1.16, y: 0.08}
-      - {x: 1.1, y: -0.11}
-      - {x: 1.0799999, y: -0.19}
-      - {x: 1.03, y: -0.39999998}
-      - {x: 1, y: -0.52}
-      - {x: 0.17999999, y: -0.52}
-      - {x: 0.17, y: -0.51}
-      - {x: -0.55, y: -0.51}
-      - {x: -0.84, y: -0.53}
-      - {x: -0.82, y: -0.44}
-      - {x: -0.77, y: -0.17999999}
-      - {x: -0.76, y: -0.08}
-      - {x: -0.76, y: 0.51}
-      - {x: -0.78999996, y: 0.62}
-      - {x: -0.96999997, y: 0.93}
-      - {x: -1.04, y: 1.03}
-      - {x: -1.13, y: 1.0799999}
-      - {x: -1.28, y: 1.0799999}
-      - {x: -1.4599999, y: 1.04}
-      - {x: -1.5899999, y: 1.03}
-      - {x: -1.7099999, y: 1.13}
-      - {x: -1.8399999, y: 1.18}
-      - {x: -1.99, y: 1.22}
-      - {x: -3.26, y: 1.22}
-      - {x: -3.27, y: 1.23}
-      - {x: -3.47, y: 1.25}
-      - {x: -4.18, y: 1.25}
-      - {x: -4.2999997, y: 1.22}
-      - {x: -4.38, y: 1.12}
-      - {x: -4.46, y: 0.96}
-      - {x: -4.5, y: 0.81}
-      - {x: -4.5, y: 0.39}
-      - {x: -4.42, y: 0.17999999}
-      - {x: -4.3399997, y: 0.04}
-      - {x: -4.27, y: -0.04}
-      - {x: -4.17, y: -0.11}
-      - {x: -3.98, y: -0.17999999}
-      - {x: -3.8899999, y: -0.19999999}
-      - {x: -3.1899998, y: -0.32999998}
-      - {x: -3.09, y: -0.34}
-      - {x: -2.71, y: -0.34}
-      - {x: -2.6499999, y: -0.32999998}
-      - {x: -2.54, y: -0.32}
-      - {x: -2.25, y: -0.25}
-      - {x: -2.07, y: -0.22}
-      - {x: -1.89, y: -0.17}
-      - {x: -1.91, y: -0.44}
-      - {x: -1.99, y: -0.77}
-      - {x: -2.03, y: -0.84}
-      - {x: -2.05, y: -0.98999995}
-      - {x: -2.28, y: -1.55}
-      - {x: -2.46, y: -1.8399999}
-      - {x: -2.45, y: -1.9399999}
-      - {x: -2.3999999, y: -1.9799999}
-      - {x: -2.37, y: -1.99}
-      - {x: -2.19, y: -1.99}
-      - {x: -1.9499999, y: -1.9499999}
-      - {x: -1.9499999, y: -1.9399999}
-      - {x: -0.45, y: -1.9399999}
-  m_UseDelaunayMesh: 0
---- !u!1 &1833094126
+  m_GameObject: {fileID: 1602292647}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.140841, y: 0.23170507, z: -0.09726234}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1715897061
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -671,135 +1159,70 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1833094129}
-  - component: {fileID: 1833094128}
-  - component: {fileID: 1833094127}
-  - component: {fileID: 1833094130}
+  - component: {fileID: 1715897062}
+  - component: {fileID: 1715897063}
   m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: Bullet
+  m_Name: Virtual Camera Player
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &1833094127
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833094126}
-  m_Enabled: 1
---- !u!20 &1833094128
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833094126}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &1833094129
+--- !u!4 &1715897062
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833094126}
+  m_GameObject: {fileID: 1715897061}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -14.37, y: -0.6, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 53218991}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1833094130
+--- !u!114 &1715897063
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833094126}
+  m_GameObject: {fileID: 1715897061}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5.69
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 53218991}
 --- !u!1 &1844479283
 GameObject:
   m_ObjectHideFlags: 0
@@ -902,6 +1325,52 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1854198337
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1854198339}
+  - component: {fileID: 1854198338}
+  m_Layer: 0
+  m_Name: CameraManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1854198338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854198337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 384448dd224ee2747aa4bebfde8c995f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vcamPlayer: {fileID: 1715897063}
+  vcamBullet: {fileID: 1040329385}
+--- !u!4 &1854198339
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854198337}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.140841, y: 0.23170507, z: -0.09726234}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1940750086
 GameObject:
   m_ObjectHideFlags: 0
@@ -1040,9 +1509,13 @@ CanvasRenderer:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1833094129}
   - {fileID: 1495371541}
   - {fileID: 1269334165}
   - {fileID: 1844479287}
   - {fileID: 512760094}
-  - {fileID: 1619051850}
+  - {fileID: 543830121}
+  - {fileID: 1392346346}
+  - {fileID: 1715897062}
+  - {fileID: 1040329386}
+  - {fileID: 1854198339}
+  - {fileID: 1602292649}

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -217,6 +217,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &347880405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 347880406}
+  m_Layer: 0
+  m_Name: -------------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &347880406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 347880405}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.389714, y: -0.6108255, z: -10.078907}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &399238260
 GameObject:
   m_ObjectHideFlags: 3
@@ -730,6 +761,50 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 28d29b35d3fb7d34e81738b4f10b7687, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &828588923
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 828588925}
+  - component: {fileID: 828588924}
+  m_Layer: 0
+  m_Name: TurnController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &828588924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828588923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 777fc099bb5cf2948b8bfa8c80ab4098, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &828588925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828588923}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.389714, y: -0.6108255, z: -10.078907}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1040329384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1505,6 +1580,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1940750086}
   m_CullTransparentMesh: 1
+--- !u!1 &1940834580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1940834581}
+  m_Layer: 0
+  m_Name: -------------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1940834581
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1940834580}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.389714, y: -0.6108255, z: -10.078907}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2005791461
 GameObject:
   m_ObjectHideFlags: 0
@@ -1677,18 +1783,53 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2088366686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2088366687}
+  m_Layer: 0
+  m_Name: ---------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2088366687
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088366686}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.389714, y: -0.6108255, z: -10.078907}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1495371541}
   - {fileID: 1269334165}
-  - {fileID: 1844479287}
-  - {fileID: 512760094}
   - {fileID: 543830121}
   - {fileID: 1392346346}
-  - {fileID: 1715897062}
-  - {fileID: 1040329386}
-  - {fileID: 1854198339}
+  - {fileID: 1940834581}
   - {fileID: 1602292649}
+  - {fileID: 1854198339}
+  - {fileID: 1495371541}
+  - {fileID: 828588925}
+  - {fileID: 2088366687}
   - {fileID: 2005791466}
+  - {fileID: 1040329386}
+  - {fileID: 1715897062}
+  - {fileID: 347880406}
+  - {fileID: 512760094}
+  - {fileID: 1844479287}

--- a/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK Test Scene.unity
@@ -806,6 +806,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 93044c97b1805d24cbdefc9d6b9b95a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  turnLimit: 5
 --- !u!114 &828588927
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## [상세 작업 내역]

- 인게임에서 플레이어를 지정된 스폰 위치에 생성합니다.
- 카메라가 턴 플레이어, 플레이어가 발사한 탄환을 따라간다
---

## [핵심 구현 원리]

- 마스터 클라이언트에서 플레이어를 생성합니다.
- 스폰된 플레이어는 각각 자신의 플레이어 오브젝트를 BattleManager에 등록하여 연동합니다.
- 플레이어의 턴이 시작되는 타이밍에 foreach를 통해 턴 플레이어를 탐색, 찾은 플레이어를 CameraController.Instance 가 따라가도록 설정
- 탄환을 발사할 때 CameraController.Instance 가 발사한 탄환을 따라가도록 설정

---

## [기능 사용 가이드]

- 플레이어 전원이 사용해야 하는 각각의 이벤트는 RegisterPlayer()에서 등록해야 합니다.
- 스폰 포인트는 List<Transforrm> 으로 되어 있습니다.
- [PunRPC] RPC_SetCameraTarget를 통해 턴 플레이어 탐색
- 탄환 생성시 [PunRPC] RPC_SetBulletTarget를 호출