### PR TITLE
가챠 프로토타입 제작

### DIFF
--- a/Assets/Workspace/HSD/HSD_Scene/Title.unity
+++ b/Assets/Workspace/HSD/HSD_Scene/Title.unity
@@ -1017,6 +1017,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 46095321}
   m_CullTransparentMesh: 1
+--- !u!1 &58605477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 58605478}
+  m_Layer: 5
+  m_Name: GameObject (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &58605478
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 58605477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &59857401
 GameObject:
   m_ObjectHideFlags: 0
@@ -3189,7 +3224,17 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 613781287}
+  - {fileID: 1424163931}
+  - {fileID: 715433147}
+  - {fileID: 58605478}
+  - {fileID: 1039773688}
+  - {fileID: 1012419641}
+  - {fileID: 808663049}
+  - {fileID: 1670100548}
+  - {fileID: 595874961}
+  - {fileID: 2022612276}
   m_Father: {fileID: 598434444}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7683,6 +7728,41 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonSelectClip: {fileID: 8300000, guid: ecc58bd60f2ad4c7a9c63cd635c147e5, type: 3}
   buttonHighlightClip: {fileID: 8300000, guid: e6403f00f8f6b451b94ac5b2edcb185e, type: 3}
+--- !u!1 &595874960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 595874961}
+  m_Layer: 5
+  m_Name: GameObject (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &595874961
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 595874960}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &598434443
 GameObject:
   m_ObjectHideFlags: 0
@@ -7700,7 +7780,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &598434444
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7713,8 +7793,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 648520955}
   - {fileID: 252119231}
+  - {fileID: 648520955}
   m_Father: {fileID: 312978511}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7769,12 +7849,22 @@ MonoBehaviour:
     icon: {fileID: 21300000, guid: e5d7a52377356dd41b31a97832b814db, type: 3}
     level: 1
     count: 1
-  cardTransform: []
+  cardTransforms:
+  - {fileID: 613781287}
+  - {fileID: 1424163931}
+  - {fileID: 715433147}
+  - {fileID: 58605478}
+  - {fileID: 1039773688}
+  - {fileID: 1012419641}
+  - {fileID: 808663049}
+  - {fileID: 1670100548}
+  - {fileID: 595874961}
+  - {fileID: 2022612276}
   gachaList: []
   cards: []
   cradContent: {fileID: 252119231}
   cardSpawnTransform: {fileID: 648520955}
-  cardPrefab: {fileID: 0}
+  cardPrefab: {fileID: 6493164010157632658, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
   moveTime: 0.5
   cardDelay: 0.2
 --- !u!1 &607988202
@@ -7911,6 +8001,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 607988202}
   m_CullTransparentMesh: 1
+--- !u!1 &613781286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 613781287}
+  m_Layer: 5
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &613781287
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613781286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &618734152
 GameObject:
   m_ObjectHideFlags: 0
@@ -8720,6 +8845,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 706866803}
   m_CullTransparentMesh: 1
+--- !u!1 &715433146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 715433147}
+  m_Layer: 5
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &715433147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 715433146}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &733320105
 GameObject:
   m_ObjectHideFlags: 0
@@ -9681,6 +9841,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 793155714}
   m_CullTransparentMesh: 1
+--- !u!1 &808663048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 808663049}
+  m_Layer: 5
+  m_Name: GameObject (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &808663049
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808663048}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &811379419
 GameObject:
   m_ObjectHideFlags: 0
@@ -12067,6 +12262,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1002300154}
   m_CullTransparentMesh: 1
+--- !u!1 &1012419640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1012419641}
+  m_Layer: 5
+  m_Name: GameObject (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1012419641
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012419640}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1033433367
 GameObject:
   m_ObjectHideFlags: 0
@@ -12225,6 +12455,41 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonSelectClip: {fileID: 8300000, guid: ecc58bd60f2ad4c7a9c63cd635c147e5, type: 3}
   buttonHighlightClip: {fileID: 8300000, guid: e6403f00f8f6b451b94ac5b2edcb185e, type: 3}
+--- !u!1 &1039773687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1039773688}
+  m_Layer: 5
+  m_Name: GameObject (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1039773688
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1039773687}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1053562570
 GameObject:
   m_ObjectHideFlags: 0
@@ -16803,6 +17068,41 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1424163930
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1424163931}
+  m_Layer: 5
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1424163931
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424163930}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1424648351
 GameObject:
   m_ObjectHideFlags: 0
@@ -19496,6 +19796,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1643216390}
   m_CullTransparentMesh: 1
+--- !u!1 &1670100547
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1670100548}
+  m_Layer: 5
+  m_Name: GameObject (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1670100548
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1670100547}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1683452095
 GameObject:
   m_ObjectHideFlags: 0
@@ -24044,6 +24379,41 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &2022612275
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2022612276}
+  m_Layer: 5
+  m_Name: GameObject (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2022612276
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2022612275}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 252119231}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2023180169
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/HSD/HSD_Scene/Title.unity
+++ b/Assets/Workspace/HSD/HSD_Scene/Title.unity
@@ -4522,6 +4522,7 @@ RectTransform:
   - {fileID: 1457583865}
   - {fileID: 1521155777}
   - {fileID: 890903447}
+  - {fileID: 598434444}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7582,6 +7583,82 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonSelectClip: {fileID: 8300000, guid: ecc58bd60f2ad4c7a9c63cd635c147e5, type: 3}
   buttonHighlightClip: {fileID: 8300000, guid: e6403f00f8f6b451b94ac5b2edcb185e, type: 3}
+--- !u!1 &598434443
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 598434444}
+  - component: {fileID: 598434446}
+  - component: {fileID: 598434445}
+  m_Layer: 5
+  m_Name: Gacha
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &598434444
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 598434443}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 643188803}
+  m_Father: {fileID: 312978511}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &598434445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 598434443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5849056, g: 0.5849056, b: 0.5849056, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &598434446
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 598434443}
+  m_CullTransparentMesh: 1
 --- !u!1 &607988202
 GameObject:
   m_ObjectHideFlags: 0
@@ -7639,7 +7716,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "tinto0604@gmail.com\u200B"
+  m_text: "\u200B"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}
   m_sharedMaterial: {fileID: -2405668869081189826, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}
@@ -8104,6 +8181,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 631943942}
+  m_CullTransparentMesh: 1
+--- !u!1 &643188802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 643188803}
+  - component: {fileID: 643188805}
+  - component: {fileID: 643188804}
+  m_Layer: 5
+  m_Name: Tank
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &643188803
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643188802}
+  m_LocalRotation: {x: -0, y: -0, z: 0.30168357, w: 0.9534082}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 598434444}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 35.118}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -897, y: -167}
+  m_SizeDelta: {x: 316.2746, y: 206.3732}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &643188804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643188802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &643188805
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 643188802}
   m_CullTransparentMesh: 1
 --- !u!1 &652091974
 GameObject:
@@ -14230,8 +14382,8 @@ Camera:
   m_GameObject: {fileID: 1225018568}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -15062,7 +15214,7 @@ MonoBehaviour:
   m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_CustomCaretColor: 0
   m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
-  m_Text: tinto0604@gmail.com
+  m_Text: 
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 1
   m_ReadOnly: 0
@@ -18055,7 +18207,7 @@ MonoBehaviour:
   m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_CustomCaretColor: 0
   m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
-  m_Text: esemi63w
+  m_Text: 
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 1
   m_ReadOnly: 0
@@ -22136,7 +22288,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1885872731}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -22723,7 +22875,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1920261800}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -24081,7 +24233,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "esemi63w\u200B"
+  m_text: "\u200B"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}
   m_sharedMaterial: {fileID: -2405668869081189826, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}

--- a/Assets/Workspace/HSD/HSD_Scene/Title.unity
+++ b/Assets/Workspace/HSD/HSD_Scene/Title.unity
@@ -3159,6 +3159,107 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &252119230
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 252119231}
+  - component: {fileID: 252119233}
+  - component: {fileID: 252119232}
+  - component: {fileID: 252119234}
+  m_Layer: 5
+  m_Name: CardList
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &252119231
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 252119230}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1873931111}
+  m_Father: {fileID: 598434444}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &252119232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 252119230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5849056, g: 0.5849056, b: 0.5849056, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &252119233
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 252119230}
+  m_CullTransparentMesh: 1
+--- !u!114 &252119234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 252119230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 300, y: 420}
+  m_Spacing: {x: 53.51, y: 83.27}
+  m_Constraint: 0
+  m_ConstraintCount: 2
 --- !u!1 &254444595
 GameObject:
   m_ObjectHideFlags: 0
@@ -7593,9 +7694,9 @@ GameObject:
   m_Component:
   - component: {fileID: 598434444}
   - component: {fileID: 598434446}
-  - component: {fileID: 598434445}
+  - component: {fileID: 598434448}
   m_Layer: 5
-  m_Name: Gacha
+  m_Name: GachaPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7613,7 +7714,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 643188803}
+  - {fileID: 648520955}
+  - {fileID: 252119231}
   m_Father: {fileID: 312978511}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7621,36 +7723,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &598434445
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 598434443}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.5849056, g: 0.5849056, b: 0.5849056, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!222 &598434446
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -7659,6 +7731,53 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 598434443}
   m_CullTransparentMesh: 1
+--- !u!114 &598434448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 598434443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673e961a69f6847458c12e9a215208b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chance:
+  - 5
+  - 20
+  - 25
+  - 50
+  isTen: 0
+  model:
+  - tankName: S_Tank
+    rank: 0
+    icon: {fileID: 21300000, guid: 7cc3590aae4bfd74fa199fece6e0c26d, type: 3}
+    level: 1
+    count: 1
+  - tankName: A_Tank
+    rank: 1
+    icon: {fileID: 21300000, guid: 5cb029aab0fa27144a51693e87da6a79, type: 3}
+    level: 1
+    count: 1
+  - tankName: B_Tank
+    rank: 2
+    icon: {fileID: 21300000, guid: c675899e3780b9f45a9105c6b1c131a5, type: 3}
+    level: 1
+    count: 1
+  - tankName: C_Tank
+    rank: 3
+    icon: {fileID: 21300000, guid: e5d7a52377356dd41b31a97832b814db, type: 3}
+    level: 1
+    count: 1
+  cardTransform: []
+  gachaList: []
+  cards: []
+  cradContent: {fileID: 252119231}
+  cardSpawnTransform: {fileID: 648520955}
+  cardPrefab: {fileID: 1873931110}
+  moveTime: 0.5
+  cardDelay: 0.2
 --- !u!1 &607988202
 GameObject:
   m_ObjectHideFlags: 0
@@ -8182,7 +8301,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 631943942}
   m_CullTransparentMesh: 1
---- !u!1 &643188802
+--- !u!1 &648520954
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8190,73 +8309,33 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 643188803}
-  - component: {fileID: 643188805}
-  - component: {fileID: 643188804}
+  - component: {fileID: 648520955}
   m_Layer: 5
-  m_Name: Tank
+  m_Name: CardSpawn
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &643188803
+--- !u!224 &648520955
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643188802}
-  m_LocalRotation: {x: -0, y: -0, z: 0.30168357, w: 0.9534082}
+  m_GameObject: {fileID: 648520954}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 598434444}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 35.118}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -897, y: -167}
-  m_SizeDelta: {x: 316.2746, y: 206.3732}
+  m_AnchoredPosition: {x: 0, y: 933}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &643188804
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643188802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &643188805
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 643188802}
-  m_CullTransparentMesh: 1
 --- !u!1 &652091974
 GameObject:
   m_ObjectHideFlags: 0
@@ -13843,58 +13922,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1161290376}
   m_CullTransparentMesh: 1
---- !u!1 &1168732222
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1168732223}
-  - component: {fileID: 1168732224}
-  m_Layer: 0
-  m_Name: GachaTest
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1168732223
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1168732222}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 619.10364, y: 256.37466, z: -0.5681413}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1168732224
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1168732222}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 673e961a69f6847458c12e9a215208b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ints: 01000000020000000300000004000000
-  chance:
-  - 5
-  - 15
-  - 30
-  - 50
-  isTen: 0
-  gachaList: []
 --- !u!1 &1171272062
 GameObject:
   m_ObjectHideFlags: 0
@@ -22223,6 +22250,16 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &1873931110 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6493164010157632658, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+  m_PrefabInstance: {fileID: 7845230180693165034}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1873931111 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+  m_PrefabInstance: {fileID: 7845230180693165034}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1885872731
 GameObject:
   m_ObjectHideFlags: 0
@@ -25394,6 +25431,103 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2117684073}
   m_CullTransparentMesh: 1
+--- !u!1001 &7845230180693165034
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 252119231}
+    m_Modifications:
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6493164010157632658, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
+      propertyPath: m_Name
+      value: Card
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -25409,4 +25543,3 @@ SceneRoots:
   - {fileID: 312978511}
   - {fileID: 244023258}
   - {fileID: 300545548}
-  - {fileID: 1168732223}

--- a/Assets/Workspace/HSD/HSD_Scene/Title.unity
+++ b/Assets/Workspace/HSD/HSD_Scene/Title.unity
@@ -1047,10 +1047,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1313.51, y: -288.365}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &59857401
 GameObject:
@@ -7758,10 +7758,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1313.51, y: -791.635}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &598434443
 GameObject:
@@ -7780,7 +7780,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &598434444
 RectTransform:
   m_ObjectHideFlags: 0
@@ -8031,10 +8031,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 252.97998, y: -288.365}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &618734152
 GameObject:
@@ -8875,10 +8875,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 960, y: -288.365}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &733320105
 GameObject:
@@ -9871,10 +9871,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 606.49, y: -791.635}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &811379419
 GameObject:
@@ -12292,10 +12292,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 252.97998, y: -791.635}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1033433367
 GameObject:
@@ -12485,10 +12485,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1667.02, y: -288.365}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1053562570
 GameObject:
@@ -17098,10 +17098,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 606.49, y: -288.365}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1424648351
 GameObject:
@@ -19826,10 +19826,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 960, y: -791.635}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1683452095
 GameObject:
@@ -24409,10 +24409,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 252119231}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1667.02, y: -791.635}
+  m_SizeDelta: {x: 300, y: 420}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2023180169
 GameObject:

--- a/Assets/Workspace/HSD/HSD_Scene/Title.unity
+++ b/Assets/Workspace/HSD/HSD_Scene/Title.unity
@@ -3189,8 +3189,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1873931111}
+  m_Children: []
   m_Father: {fileID: 598434444}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7701,7 +7700,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &598434444
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7775,7 +7774,7 @@ MonoBehaviour:
   cards: []
   cradContent: {fileID: 252119231}
   cardSpawnTransform: {fileID: 648520955}
-  cardPrefab: {fileID: 1873931110}
+  cardPrefab: {fileID: 0}
   moveTime: 0.5
   cardDelay: 0.2
 --- !u!1 &607988202
@@ -22250,16 +22249,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!1 &1873931110 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6493164010157632658, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-  m_PrefabInstance: {fileID: 7845230180693165034}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &1873931111 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-  m_PrefabInstance: {fileID: 7845230180693165034}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1885872731
 GameObject:
   m_ObjectHideFlags: 0
@@ -25431,103 +25420,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2117684073}
   m_CullTransparentMesh: 1
---- !u!1001 &7845230180693165034
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 252119231}
-    m_Modifications:
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5178129087208333178, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6493164010157632658, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
-      propertyPath: m_Name
-      value: Card
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 181f46ebb22e6bd41b1a5a847c958fce, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/HSD/Prefabs/Test.meta
+++ b/Assets/Workspace/HSD/Prefabs/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f92fb05c16dae244ca8e88a18af16c1b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/HSD/Prefabs/Test/Card.prefab
+++ b/Assets/Workspace/HSD/Prefabs/Test/Card.prefab
@@ -1,0 +1,535 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1396676724467546305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4304113959452679341}
+  - component: {fileID: 1582948027616085783}
+  - component: {fileID: 4785723651404869082}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4304113959452679341
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396676724467546305}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3544835204424757719}
+  - {fileID: 775345272618353674}
+  m_Father: {fileID: 5178129087208333178}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.0000076293945}
+  m_SizeDelta: {x: 280.8931, y: 393.2503}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1582948027616085783
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396676724467546305}
+  m_CullTransparentMesh: 1
+--- !u!114 &4785723651404869082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1396676724467546305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3584906, g: 0.3534176, b: 0.3534176, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3487700795677862529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3544835204424757719}
+  - component: {fileID: 5585185050082739941}
+  - component: {fileID: 2074203584337957036}
+  m_Layer: 5
+  m_Name: IconSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3544835204424757719
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3487700795677862529}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4250704141859972134}
+  m_Father: {fileID: 4304113959452679341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.95500004}
+  m_AnchorMax: {x: 0.5, y: 0.95500004}
+  m_AnchoredPosition: {x: 0, y: -76.14951}
+  m_SizeDelta: {x: 150, y: 136.3912}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5585185050082739941
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3487700795677862529}
+  m_CullTransparentMesh: 1
+--- !u!114 &2074203584337957036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3487700795677862529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.7607843}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4349785260722265106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 775345272618353674}
+  - component: {fileID: 3524816575720375299}
+  - component: {fileID: 632583583749747756}
+  m_Layer: 5
+  m_Name: TankName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &775345272618353674
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349785260722265106}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4304113959452679341}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -2.2681}
+  m_SizeDelta: {x: 276.1824, y: 45.4637}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3524816575720375299
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349785260722265106}
+  m_CullTransparentMesh: 1
+--- !u!114 &632583583749747756
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4349785260722265106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TankName
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}
+  m_sharedMaterial: {fileID: -2405668869081189826, guid: 76af3728e683ec24fb2343b741eaa4f8, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4292598747
+  m_fontColor: {r: 0.8584906, g: 0.8584906, b: 0.8584906, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5013738059184304202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4250704141859972134}
+  - component: {fileID: 3651015730797035081}
+  - component: {fileID: 4713358942422926243}
+  m_Layer: 5
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4250704141859972134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5013738059184304202}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3544835204424757719}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.0000019073486}
+  m_SizeDelta: {x: 136.2316, y: 123.4807}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3651015730797035081
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5013738059184304202}
+  m_CullTransparentMesh: 1
+--- !u!114 &4713358942422926243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5013738059184304202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6493164010157632658
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5178129087208333178}
+  - component: {fileID: 8384887761579595675}
+  - component: {fileID: 6541455387433336681}
+  - component: {fileID: 6237791414142228347}
+  - component: {fileID: 799281636894721109}
+  - component: {fileID: 2622367966954707005}
+  m_Layer: 5
+  m_Name: Card
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5178129087208333178
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4304113959452679341}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8384887761579595675
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_CullTransparentMesh: 1
+--- !u!114 &6541455387433336681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9433962, g: 0.91489476, b: 0.35154858, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6237791414142228347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e23dced59c762b44b2b97b705d41767, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tankIcon: {fileID: 4713358942422926243}
+  rankImage: {fileID: 6541455387433336681}
+  card: {fileID: 799281636894721109}
+  tankName: {fileID: 632583583749747756}
+  anim: {fileID: 2622367966954707005}
+  tankData:
+    tankName: 
+    rank: 0
+    icon: {fileID: 0}
+    level: 0
+    count: 0
+  sColor: {r: 0.9647059, g: 0.7616729, b: 0.25882357, a: 1}
+  aColor: {r: 0.2082592, g: 0.7114958, b: 0.9811321, a: 1}
+  bColor: {r: 0.55422074, g: 0.9622642, b: 0.29503384, a: 1}
+  cColor: {r: 0.754717, g: 0.7226771, b: 0.7226771, a: 1}
+--- !u!114 &799281636894721109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 3
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6541455387433336681}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!95 &2622367966954707005
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6493164010157632658}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/Assets/Workspace/HSD/Prefabs/Test/Card.prefab.meta
+++ b/Assets/Workspace/HSD/Prefabs/Test/Card.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 181f46ebb22e6bd41b1a5a847c958fce
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/HSD/Scripts/Backend/LoginManager.cs
+++ b/Assets/Workspace/HSD/Scripts/Backend/LoginManager.cs
@@ -264,6 +264,7 @@ public class LoginManager : MonoBehaviourPunCallbacks
         Manager.UI.FadeScreen.FadeOut(1);
         Manager.Game.State = Game.State.Lobby;
         Manager.Database.userRef.Child(UserDataType.Connected.ToString()).SetValueAsync(true);
+        Manager.Database.userRef.Child(UserDataType.Connected.ToString()).OnDisconnect().SetValue(false);
         Manager.Data.InventoryData = new();
 
         if (string.IsNullOrEmpty(Manager.Data.PlayerData.Name))

--- a/Assets/Workspace/HSD/Scripts/Data/InventoryData.cs
+++ b/Assets/Workspace/HSD/Scripts/Data/InventoryData.cs
@@ -4,18 +4,22 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
-public enum TestTankRank
+public enum TankRank
 {
     S, A, B, C
 }
 
+public class TankData
+{
 
-// 레벨에 따른 탱크 갯수를 관리하는 클래스
+}
+
+// 레벨에 따른 탱크 갯수를 관리하는 클래스 (데이터 베이스 저장용 데이터)
 [Serializable]
 public class TankGroupData
 {
     public string TankName;
-    public TestTankRank Rank;
+    public TankRank Rank;
     public Dictionary<int, int> Levels = new();
 }
 
@@ -54,14 +58,6 @@ public class InventoryData
 
         InitData().ContinueWithOnMainThread(task =>
         {
-            Manager.Database.userRef.Child("Tanks").GetValueAsync().ContinueWithOnMainThread(task =>
-            {
-                if (task.IsFaulted || task.IsCanceled)
-                {
-                    tankRef = Manager.Database.userRef.Child("Tanks");
-                    InitInventory();
-                }
-            });
             InitInventory();
         });
     }
@@ -101,7 +97,7 @@ public class InventoryData
         }
 
         var rankStr = args.Snapshot.Child("Rank")?.Value?.ToString();
-        if (!string.IsNullOrEmpty(rankStr) && Enum.TryParse(rankStr, out TestTankRank rank))
+        if (!string.IsNullOrEmpty(rankStr) && Enum.TryParse(rankStr, out TankRank rank))
         {
             groupData.Rank = rank;
         }
@@ -132,7 +128,7 @@ public class InventoryData
         string tankName = snapshot.Key; // 탱크 이름 가져옴
 
         var rankStr = snapshot.Child("Rank")?.Value?.ToString();    // 랭크 가져옴
-        var rankParsed = Enum.TryParse(rankStr, out TestTankRank rank) ? rank : TestTankRank.C;
+        var rankParsed = Enum.TryParse(rankStr, out TankRank rank) ? rank : TankRank.C;
 
         // 가져온 데이터를 기반으로 그룹을 만들어줌
         var groupData = new TankGroupData
@@ -161,7 +157,7 @@ public class InventoryData
     private Task CreateTankGroupData(string tankName, int level)
     {
         // 랭크는 추후 프리팹에서 key값으로 가져옴
-        TestTankRank rank = TestTankRank.C;
+        TankRank rank = TankRank.C;
 
         return tankRef.GetValueAsync().ContinueWithOnMainThread(task =>
         {
@@ -195,7 +191,7 @@ public class InventoryData
         });
     }
 
-    public Task AddTank(string tankName, int level, int count, TestTankRank rank = TestTankRank.C)
+    public Task AddTank(string tankName, int level, int count, TankRank rank = TankRank.C)
     {
         var countRef = tankRef.Child(tankName).Child("Levels").Child(level.ToString()).Child("Count");
 

--- a/Assets/Workspace/HSD/Scripts/Data/InventoryData.cs
+++ b/Assets/Workspace/HSD/Scripts/Data/InventoryData.cs
@@ -9,11 +9,6 @@ public enum TankRank
     S, A, B, C
 }
 
-public class TankData
-{
-
-}
-
 // 레벨에 따른 탱크 갯수를 관리하는 클래스 (데이터 베이스 저장용 데이터)
 [Serializable]
 public class TankGroupData

--- a/Assets/Workspace/HSD/Scripts/Data/PlayerData.cs
+++ b/Assets/Workspace/HSD/Scripts/Data/PlayerData.cs
@@ -87,7 +87,7 @@ public class PlayerData
     // 추후 논의 후 이전 가능성이 있습니다.
     public void GemGain(int amount)
     {
-        Manager.Database.userRef.Child("gem")
+        Manager.Database.userDataRef.Child("Gem")
         .SetValueAsync(Gem + amount).ContinueWithOnMainThread(task =>
         {
             if (task.IsCompleted)

--- a/Assets/Workspace/HSD/Scripts/Manager/FirebaseManager.cs
+++ b/Assets/Workspace/HSD/Scripts/Manager/FirebaseManager.cs
@@ -49,7 +49,7 @@ public class FirebaseManager : Singleton<FirebaseManager>
                 Debug.LogError("파베 설정이 충족되지 않음");
             }
             OnAuthSettingComplated?.Invoke();
-        });
+        });        
     }
 
     public void LogOut()

--- a/Assets/Workspace/HSD/Scripts/System/Card.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Card.cs
@@ -21,15 +21,15 @@ public class Card : MonoBehaviour
     [SerializeField] Color bColor;
     [SerializeField] Color cColor;
 
-    public void SetUp(TankData _tankData, Transform _transform, float _moveTime)
+    public void SetUp(TankData tankData, Transform targetTransform, float moveTime)
     {
-        tankData = _tankData;
+        this.tankData = tankData;
 
-        tankName.text = tankData.tankName;
-        tankIcon.sprite = tankData.icon;
-        rankImage.color = GetRankColor(tankData.rank);
+        tankName.text = this.tankData.tankName;
+        tankIcon.sprite = this.tankData.icon;
+        rankImage.color = GetRankColor(this.tankData.rank);
 
-        StartCoroutine(MoveRoutine(_transform, _moveTime));
+        StartCoroutine(MoveRoutine(targetTransform, moveTime));
     }
 
     private Color GetRankColor(TankRank rank)
@@ -50,17 +50,20 @@ public class Card : MonoBehaviour
         card.interactable = false;
     }
 
-    private IEnumerator MoveRoutine(Transform _transform, float _moveTime)
+    private IEnumerator MoveRoutine(Transform targetTransform, float moveTime)
     {
         float timer = 0;
         Vector2 start = transform.position;
+        Vector3 end = targetTransform.position;
 
-        while (timer < _moveTime)
+        while (timer < moveTime)
         {
-            Vector2.Lerp(start, _transform.position, timer / _moveTime);
+            transform.position = Vector2.Lerp(start, end, timer / moveTime);
             timer += Time.deltaTime;
 
             yield return null;
         }
+
+        transform.position = end;
     }
 }

--- a/Assets/Workspace/HSD/Scripts/System/Card.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Card.cs
@@ -55,7 +55,7 @@ public class Card : MonoBehaviour
         float timer = 0;
         Vector2 start = transform.position;
 
-        while (timer > _moveTime)
+        while (timer < _moveTime)
         {
             Vector2.Lerp(start, _transform.position, timer / _moveTime);
             timer += Time.deltaTime;

--- a/Assets/Workspace/HSD/Scripts/System/Card.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Card.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class Card : MonoBehaviour
+{
+    [Header("UI")]
+    [SerializeField] Image tankIcon;
+    [SerializeField] Image rankImage;
+    [SerializeField] Button card;
+    [SerializeField] TMP_Text tankName;
+    [SerializeField] Animator anim;
+
+    [SerializeField] TankData tankData;
+
+    [Header("Color")]
+    [SerializeField] Color sColor;
+    [SerializeField] Color aColor;
+    [SerializeField] Color bColor;
+    [SerializeField] Color cColor;
+
+    public void SetUp(TankData _tankData, Transform _transform, float _moveTime)
+    {
+        tankData = _tankData;
+
+        tankName.text = tankData.tankName;
+        tankIcon.sprite = tankData.icon;
+        rankImage.color = GetRankColor(tankData.rank);
+
+        StartCoroutine(MoveRoutine(_transform, _moveTime));
+    }
+
+    private Color GetRankColor(TankRank rank)
+    {
+        return (rank) switch
+        {
+            TankRank.C => cColor,
+            TankRank.B => bColor,
+            TankRank.A => aColor,
+            TankRank.S => sColor,
+            _ => cColor,
+        };
+    }
+
+    private void Open()
+    {
+        anim.SetTrigger("Open");
+        card.interactable = false;
+    }
+
+    private IEnumerator MoveRoutine(Transform _transform, float _moveTime)
+    {
+        float timer = 0;
+        Vector2 start = transform.position;
+
+        while (timer > _moveTime)
+        {
+            Vector2.Lerp(start, _transform.position, timer / _moveTime);
+            timer += Time.deltaTime;
+
+            yield return null;
+        }
+    }
+}

--- a/Assets/Workspace/HSD/Scripts/System/Card.cs.meta
+++ b/Assets/Workspace/HSD/Scripts/System/Card.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e23dced59c762b44b2b97b705d41767
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Workspace/HSD/Scripts/System/Gacha.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Gacha.cs
@@ -11,7 +11,7 @@ public class Gacha : MonoBehaviour
     [SerializeField] TankData[] model;
 
     [Header("List")]
-    [SerializeField] List<Transform> cardTransform = new();
+    [SerializeField] List<Transform> cardTransforms = new();
     [SerializeField] List<TankData> gachaList = new();
 
     [Header("Cards")]
@@ -40,9 +40,9 @@ public class Gacha : MonoBehaviour
     [ContextMenu("Gacha")]
     public void TryGacha()
     {
-        cardTransform.Clear();
+        SetUpCardTransformList();
+        ClearCards();
         gachaList.Clear();
-        cards.Clear();
 
         if (isTen)
         {
@@ -78,11 +78,6 @@ public class Gacha : MonoBehaviour
 
         TankData selectTank = randomData[Random.Range(0, randomData.Length)];
 
-        GameObject cardPosObj = new GameObject("Card");
-        cardPosObj.transform.SetParent(cradContent, false);
-
-        cardTransform.Add(cardPosObj.transform);
-
         Card card = Instantiate(cardPrefab, cardSpawnTransform.position, Quaternion.identity, cardSpawnTransform).GetComponent<Card>();
         cards.Add(card);
 
@@ -91,11 +86,40 @@ public class Gacha : MonoBehaviour
         return selectTank;
     }
 
+    private void SetUpCardTransformList()
+    {
+        if(isTen)
+        {
+            foreach(Transform t in cardTransforms)
+            {
+                t.gameObject.SetActive(true);
+            }
+        }
+        else
+        {
+            for(int i = 0; i < cardTransforms.Count; i++)
+            {
+                if(i == 0)
+                    cardTransforms[i].gameObject.SetActive(true);
+                else
+                    cardTransforms[i].gameObject.SetActive(false);
+            }
+        }
+    }
+    private void ClearCards()
+    {
+        foreach (Card c in cards)
+        {
+            Destroy(c.gameObject);
+        }
+        cards.Clear();
+    }
+
     private IEnumerator SetUpCardRoutine()
     {
         for (int i = 0;i < cards.Count; i++)
         {
-            cards[i].SetUp(gachaList[i], cardTransform[i], moveTime);
+            cards[i].SetUp(gachaList[i], cardTransforms[i], moveTime);
             yield return delay;
         }
     }

--- a/Assets/Workspace/HSD/Scripts/System/Gacha.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Gacha.cs
@@ -6,7 +6,6 @@ using UnityEngine;
 public class Gacha : MonoBehaviour
 {
     [Header("Setting")]
-    [SerializeField] int[] ints;
     [SerializeField] float[] chance;
     [SerializeField] bool isTen;
     [SerializeField] TankData[] model;
@@ -32,10 +31,18 @@ public class Gacha : MonoBehaviour
         delay = new WaitForSeconds(cardDelay);
     }
 
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+            StartCoroutine(SetUpCardRoutine());
+    }
+
     [ContextMenu("Gacha")]
     public void TryGacha()
     {
+        cardTransform.Clear();
         gachaList.Clear();
+        cards.Clear();
 
         if (isTen)
         {
@@ -50,12 +57,7 @@ public class Gacha : MonoBehaviour
 
     private TankData GetRandomTank()
     {
-        float rand = Random.Range(0, ints.Length);
-
-        TankData[] randomData = model.
-            Where(t => (int)t.rank == (int)rand).ToArray();
-
-        rand = Random.Range(0, 100);
+        float rand = Random.Range(0, 100);
 
         int select = 0;
 
@@ -71,20 +73,30 @@ public class Gacha : MonoBehaviour
             }
         }
 
-        TankData selectTank = randomData[select];
+        TankData[] randomData = model.
+            Where(t => (int)t.rank == select).ToArray();
+
+        TankData selectTank = randomData[Random.Range(0, randomData.Length)];
 
         GameObject cardPosObj = new GameObject("Card");
         cardPosObj.transform.SetParent(cradContent, false);
 
         cardTransform.Add(cardPosObj.transform);
 
+        Card card = Instantiate(cardPrefab, cardSpawnTransform.position, Quaternion.identity).GetComponent<Card>();        
+        cards.Add(card);
+
         Manager.Data.InventoryData.AddTank(selectTank.tankName, selectTank.level, selectTank.count, selectTank.rank);
 
         return selectTank;
     }
 
-    private void SetUpCard()
+    private IEnumerator SetUpCardRoutine()
     {
-
+        for (int i = 0;i < cards.Count; i++)
+        {
+            cards[i].SetUp(gachaList[i], cardTransform[i], moveTime);
+            yield return delay;
+        }
     }
 }

--- a/Assets/Workspace/HSD/Scripts/System/Gacha.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Gacha.cs
@@ -83,7 +83,7 @@ public class Gacha : MonoBehaviour
 
         cardTransform.Add(cardPosObj.transform);
 
-        Card card = Instantiate(cardPrefab, cardSpawnTransform.position, Quaternion.identity).GetComponent<Card>();        
+        Card card = Instantiate(cardPrefab, cardSpawnTransform.position, Quaternion.identity, cardSpawnTransform).GetComponent<Card>();
         cards.Add(card);
 
         Manager.Data.InventoryData.AddTank(selectTank.tankName, selectTank.level, selectTank.count, selectTank.rank);

--- a/Assets/Workspace/HSD/Scripts/System/Gacha.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Gacha.cs
@@ -8,7 +8,8 @@ public class Gacha : MonoBehaviour
     [SerializeField] int[] ints;
     [SerializeField] float[] chance;
     [SerializeField] bool isTen;
-    [SerializeField] private List<TankGroupData> gachaList = new();
+    [SerializeField] private TankData[] model;
+    [SerializeField] private List<TankData> gachaList = new();
 
     [ContextMenu("Gacha")]
     public void TryGacha()
@@ -26,12 +27,12 @@ public class Gacha : MonoBehaviour
             gachaList.Add(GetRandomTank());
     }
 
-    private TankGroupData GetRandomTank()
+    private TankData GetRandomTank()
     {
         float rand = Random.Range(0, ints.Length);
 
-        TankGroupData[] randomData = Manager.Data.InventoryData.tankGroups.Values.
-            Where(t => (int)t.Rank == (int)rand).ToArray();
+        TankData[] randomData = model.
+            Where(t => (int)t.rank == (int)rand).ToArray();
 
         rand = Random.Range(0, 100);
 
@@ -49,6 +50,10 @@ public class Gacha : MonoBehaviour
             }
         }
 
-        return randomData[select];
+        TankData selectTank = randomData[select];
+
+        Manager.Data.InventoryData.AddTank(selectTank.tankName, selectTank.level, selectTank.count, selectTank.rank);
+
+        return selectTank;
     }
 }

--- a/Assets/Workspace/HSD/Scripts/System/Gacha.cs
+++ b/Assets/Workspace/HSD/Scripts/System/Gacha.cs
@@ -5,11 +5,32 @@ using UnityEngine;
 
 public class Gacha : MonoBehaviour
 {
+    [Header("Setting")]
     [SerializeField] int[] ints;
     [SerializeField] float[] chance;
     [SerializeField] bool isTen;
-    [SerializeField] private TankData[] model;
-    [SerializeField] private List<TankData> gachaList = new();
+    [SerializeField] TankData[] model;
+
+    [Header("List")]
+    [SerializeField] List<Transform> cardTransform = new();
+    [SerializeField] List<TankData> gachaList = new();
+
+    [Header("Cards")]
+    [SerializeField] List<Card> cards = new();
+    [SerializeField] Transform cradContent;
+    [SerializeField] Transform cardSpawnTransform;
+    [SerializeField] GameObject cardPrefab;
+
+    [Header("Move")]
+    [SerializeField] float moveTime;
+    [SerializeField] float cardDelay;
+
+    private YieldInstruction delay;
+
+    private void Start()
+    {
+        delay = new WaitForSeconds(cardDelay);
+    }
 
     [ContextMenu("Gacha")]
     public void TryGacha()
@@ -52,8 +73,18 @@ public class Gacha : MonoBehaviour
 
         TankData selectTank = randomData[select];
 
+        GameObject cardPosObj = new GameObject("Card");
+        cardPosObj.transform.SetParent(cradContent, false);
+
+        cardTransform.Add(cardPosObj.transform);
+
         Manager.Data.InventoryData.AddTank(selectTank.tankName, selectTank.level, selectTank.count, selectTank.rank);
 
         return selectTank;
+    }
+
+    private void SetUpCard()
+    {
+
     }
 }

--- a/Assets/Workspace/MSK/MSK Scripts/TankData.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/TankData.cs
@@ -7,7 +7,8 @@ using UnityEngine;
 public class TankData
 {
     public string tankName;
-    public int count;
-    public int rank;
+    public TankRank rank;
+    public Sprite icon;
     public int level;
+    public int count;
 }


### PR DESCRIPTION
# 작업한 내용
- 기본적인 가챠 구현
- 가챠 연출 추가 (더 자연스럽게 나눠지고 클릭하면 뒤집어지면서 확인하는 식으로 수정 예정)
![2025-07-30 09-35-54](https://github.com/user-attachments/assets/e6d874f1-6cc3-4d46-b6b7-86505f3221f6)
(데이터 베이스 데이터 추가도 확인 완료)
- 작업 관리자 종료 시에도 정상적으로 종료되도록 수정