### PR TITLE
[Fix] Player Myinfo null 오류 수정

### DIFF
--- a/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/PlayerController.cs
@@ -49,11 +49,12 @@ public class PlayerController : MonoBehaviourPun, IPunObservable
         originalGravityScale = _rigidbody.gravityScale;
         _rigidbody.bodyType = RigidbodyType2D.Dynamic;
 
+        myInfo = new PlayerInfo(photonView.Owner);
         if (photonView.IsMine)
         {
             _movable = _data.maxMove;
             _hp = _data.maxHp;
-            myInfo = new PlayerInfo(photonView.Owner);
+
             TestBattleManager battleManager = FindObjectOfType<TestBattleManager>();
             MSK_UIManager uiManager = FindObjectOfType<MSK_UIManager>();
 

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
@@ -25,6 +25,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
     [SerializeField] ResultUI ResultPanel;
     [SerializeField] InGameUI inGameUI;
     [SerializeField] TextMeshProUGUI CountText;
+
     [Header("탱크 리스트 확인용")]
     [SerializeField] List<PlayerController> tanks = new();
     [SerializeField] GameObject Arrow;
@@ -405,9 +406,10 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
                 losers.Add(player);
         }
 
-        foreach (var tank in tanks)
+        foreach (var tank in tanks.ToList())
         {
-            tank.GetComponent<Collider2D>().enabled = false;
+            if (tank != null)
+                tank.GetComponent<Collider2D>().enabled = false;
         }
 
         photonView.RPC("ResultActivate", RpcTarget.All);
@@ -476,6 +478,7 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
         if (team == Team.Red) redRemain--;
         else blueRemain--;
         currentPlayer.RecordKillCount();
+        Debug.Log($"[OnPlayerDied] 플레이어가 포톤 마이 인포 널? {player.myInfo == null}");
 
         DeadPlayer.Add(player.myInfo.ActorNumber);
         Debug.Log($"[MSKTurn] 팀 {team} 남은 인원: {(team == Team.Red ? redRemain : blueRemain)}");

--- a/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
+++ b/Assets/Workspace/MSK/MSK Scripts/Test/MSKTurnController.cs
@@ -375,8 +375,6 @@ public class MSKTurnController : MonoBehaviourPunCallbacks
     [PunRPC]
     private void RPC_GameEnded(Team winnerTeam)
     {
-        if (isGameEnd) return;
-
         isTurnRunning = false;
         isGameEnd = true;
         Debug.Log("게임 종료!");

--- a/Assets/Workspace/MSK/Test Scene/MSK InGameTest.unity
+++ b/Assets/Workspace/MSK/Test Scene/MSK InGameTest.unity
@@ -3324,7 +3324,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 718858781}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -7671,6 +7671,7 @@ MonoBehaviour:
   itemSpawner: {fileID: 0}
   itemCount: 0
   ResultPanel: {fileID: 920666501}
+  inGameUI: {fileID: 1574390735}
   CountText: {fileID: 1229694190}
   tanks: []
   Arrow: {fileID: 3370305161053916214, guid: ef03ac441a28396479ecdb8d38009675, type: 3}
@@ -7810,8 +7811,6 @@ MonoBehaviour:
   item1Button: {fileID: 718079426}
   item2Button: {fileID: 2045418933}
   endTurnButton: {fileID: 1225509752}
-  item1Icon: {fileID: 718079427}
-  item2Icon: {fileID: 2045418934}
   healthPointText: {fileID: 847118187}
 --- !u!114 &1574390736
 MonoBehaviour:
@@ -9870,3 +9869,4 @@ SceneRoots:
   - {fileID: 1448513394}
   - {fileID: 1857165070}
   - {fileID: 335403836}
+  - {fileID: 679817609}


### PR DESCRIPTION
if (photonView.IsMine) 으로 자기 자신에 대한 인포만 초기화하여 다른 플레이어의 정보를 초기화 하지 못하여 발생하는 이슈입니다.


        myInfo = new PlayerInfo(photonView.Owner);

조건문 전으로 플레이어 정보를 초기화 하여 수정했습니다.